### PR TITLE
MULE-12602: Allowing non top level elements to have a "name" parameter

### DIFF
--- a/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
@@ -65,7 +65,7 @@ public class ErrorHandlingConfigurationFailuresTestCase extends AbstractMuleTest
       useXalan = null;
     }
   }
-  
+
   @Test(expected = ConfigurationException.class)
   public void errorHandlerCantHaveMiddleExceptionStrategyWithoutExpression() throws Exception {
     loadConfiguration("org/mule/test/integration/exceptions/exception-strategy-in-choice-without-expression.xml");

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
@@ -65,12 +65,7 @@ public class ErrorHandlingConfigurationFailuresTestCase extends AbstractMuleTest
       useXalan = null;
     }
   }
-
-  @Test(expected = ConfigurationException.class)
-  public void namedFlowExceptionStrategyFails() throws Exception {
-    loadConfiguration("org/mule/test/integration/exceptions/named-flow-exception-strategy.xml");
-  }
-
+  
   @Test(expected = ConfigurationException.class)
   public void errorHandlerCantHaveMiddleExceptionStrategyWithoutExpression() throws Exception {
     loadConfiguration("org/mule/test/integration/exceptions/exception-strategy-in-choice-without-expression.xml");


### PR DESCRIPTION
… functionality was added, that exception is not thrown anymore