### PR TITLE
MULE-12606: Remove org.apache.commons from exported packages

### DIFF
--- a/soap-connect/soap-extension/pom.xml
+++ b/soap-connect/soap-extension/pom.xml
@@ -35,4 +35,15 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
_ Skipping deploy for soap test extension