### PR TITLE
MULE-12663: In Message Filter, When unaccepted events are handled, ex…

### DIFF
--- a/integration/src/test/java/org/mule/test/core/routing/outbound/MessageFilterCompatibilityFunctionalTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/routing/outbound/MessageFilterCompatibilityFunctionalTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.core.routing.outbound;
+
+import static org.mule.functional.api.component.FlowAssert.verify;
+import static org.mule.runtime.core.processor.AbstractFilteringMessageProcessor.FILTER_ON_UNACCEPTED_NOT_STOP_PARENT_FLOW;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.mule.test.AbstractIntegrationTestCase;
+
+public class MessageFilterCompatibilityFunctionalTestCase extends AbstractIntegrationTestCase {
+
+  @Rule
+  public SystemProperty systemProperty = new SystemProperty(FILTER_ON_UNACCEPTED_NOT_STOP_PARENT_FLOW, "true");
+
+  @Override
+  protected String getConfigFile() {
+    return "message-filter-compatibility-config.xml";
+  }
+
+  @Test
+  public void testFlowCallerStopsAfterUnacceptedEvent() throws Exception {
+    runFlow("MainFlow");
+    verify();
+  }
+
+}

--- a/integration/src/test/java/org/mule/test/core/routing/outbound/MessageFilterFunctionalTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/routing/outbound/MessageFilterFunctionalTestCase.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.core.routing.outbound;
+
+import static org.mule.functional.api.component.FlowAssert.verify;
+
+import org.junit.Test;
+
+import org.mule.test.AbstractIntegrationTestCase;
+
+public class MessageFilterFunctionalTestCase extends AbstractIntegrationTestCase {
+
+  @Test
+  public void testFlowCallerStopsAfterUnacceptedEvent() throws Exception {
+    runFlow("MainFlow");
+    verify();
+  }
+
+  @Override
+  protected String getConfigFile() {
+    return "message-filter-config.xml";
+  }
+
+}

--- a/integration/src/test/resources/message-filter-compatibility-config.xml
+++ b/integration/src/test/resources/message-filter-compatibility-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <flow name="MainFlow">
+        <set-variable variableName="flag" value="false"/>
+        <flow-ref name="SubFlow_Level1"/>
+        <test:assert count="1"/>
+    </flow>
+
+    <sub-flow name="SubFlow_Level1" >
+        <message-filter onUnaccepted="SubFlow_level2">
+            <expression-filter expression="#[mel:flowVars.flag == true]"/>
+        </message-filter>
+    </sub-flow>
+
+    <sub-flow name="SubFlow_level2">
+        <test:assert count="1"/>
+    </sub-flow>
+</mule>

--- a/integration/src/test/resources/message-filter-config.xml
+++ b/integration/src/test/resources/message-filter-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <flow name="MainFlow">
+        <set-variable variableName="flag" value="true"/>
+        <flow-ref name="SubFlow_Level1"/>
+        <test:assert count="0"/>
+    </flow>
+
+    <sub-flow name="SubFlow_Level1" >
+        <message-filter onUnaccepted="SubFlow_level2">
+            <expression-filter expression="#[mel:flowVars.flag == false]"/>
+        </message-filter>
+    </sub-flow>
+
+    <sub-flow name="SubFlow_level2">
+        <test:assert count="1"/>
+    </sub-flow>
+
+</mule>


### PR DESCRIPTION
…ecution of flow caller is not stopped.

In a subflow with a filter, if the filter condition is not satisfied and the unaccepted event is handled, then the flow that called this subflow must
stop its execution.