### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/integration/src/test/java/org/mule/test/config/IdempotentMessageValidatorNamespaceHandlerTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/IdempotentMessageValidatorNamespaceHandlerTestCase.java
@@ -16,7 +16,7 @@ import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.core.routing.IdempotentMessageValidator;
-import org.mule.runtime.core.util.store.SimpleMemoryObjectStore;
+import org.mule.runtime.core.api.store.SimpleMemoryObjectStore;
 import org.mule.test.AbstractIntegrationTestCase;
 
 import java.io.Serializable;

--- a/integration/src/test/java/org/mule/test/routing/CollectionAggregatorRouterCustomStoreTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/CollectionAggregatorRouterCustomStoreTestCase.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.client.MuleClient;
 import org.mule.runtime.api.store.ObjectStoreException;
-import org.mule.runtime.core.util.store.PartitionedInMemoryObjectStore;
+import org.mule.runtime.core.api.store.PartitionedInMemoryObjectStore;
 import org.mule.test.AbstractIntegrationTestCase;
 
 import java.io.Serializable;

--- a/integration/src/test/java/org/mule/test/routing/CollectionAggregatorRouterSerializationTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/CollectionAggregatorRouterSerializationTestCase.java
@@ -16,7 +16,7 @@ import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.api.serialization.SerializationException;
 import org.mule.runtime.api.store.ObjectStoreException;
 import org.mule.runtime.core.routing.EventGroup;
-import org.mule.runtime.core.util.store.SimpleMemoryObjectStore;
+import org.mule.runtime.core.api.store.SimpleMemoryObjectStore;
 import org.mule.test.AbstractIntegrationTestCase;
 
 import java.io.Serializable;

--- a/integration/src/test/java/org/mule/test/routing/UntilSuccessfulTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/UntilSuccessfulTestCase.java
@@ -26,7 +26,7 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyExhaustedException;
-import org.mule.runtime.core.util.store.AbstractPartitionedObjectStore;
+import org.mule.runtime.core.api.store.AbstractPartitionedObjectStore;
 import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 import org.mule.test.AbstractIntegrationTestCase;

--- a/integration/src/test/java/org/mule/test/usecases/routing/response/ResponseAggregatorTestCase.java
+++ b/integration/src/test/java/org/mule/test/usecases/routing/response/ResponseAggregatorTestCase.java
@@ -19,7 +19,7 @@ import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.message.GroupCorrelation;
 import org.mule.runtime.core.routing.requestreply.AbstractAsyncRequestReplyRequester;
 import org.mule.runtime.core.api.util.IOUtils;
-import org.mule.runtime.core.util.store.SimpleMemoryObjectStore;
+import org.mule.runtime.core.api.store.SimpleMemoryObjectStore;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.runtime.http.api.domain.message.request.HttpRequest;

--- a/integration/src/test/java/org/mule/test/usecases/routing/response/SerializationOnResponseAggregatorTestCase.java
+++ b/integration/src/test/java/org/mule/test/usecases/routing/response/SerializationOnResponseAggregatorTestCase.java
@@ -14,7 +14,7 @@ import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.api.serialization.ObjectSerializer;
 import org.mule.runtime.core.api.util.IOUtils;
-import org.mule.runtime.core.util.store.SimpleMemoryObjectStore;
+import org.mule.runtime.core.api.store.SimpleMemoryObjectStore;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.runtime.http.api.domain.message.request.HttpRequest;

--- a/integration/src/test/resources/collection-aggregator-router-custom-store.xml
+++ b/integration/src/test/resources/collection-aggregator-router-custom-store.xml
@@ -9,7 +9,7 @@
                http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
     <spring:beans>
-        <spring:bean id="processed-groups-object-store" class="org.mule.runtime.core.util.store.SimpleMemoryObjectStore"/>
+        <spring:bean id="processed-groups-object-store" class="org.mule.runtime.core.api.store.SimpleMemoryObjectStore"/>
         <spring:bean id="event-groups-object-store" class="org.mule.test.routing.CollectionAggregatorRouterCustomStoreTestCase.CustomPartitionableObjectStore"/>
     </spring:beans>
 

--- a/integration/src/test/resources/org/mule/test/integration/exceptions/exception-handling-test.xml
+++ b/integration/src/test/resources/org/mule/test/integration/exceptions/exception-handling-test.xml
@@ -9,8 +9,8 @@
        http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd
        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.PartitionedPersistentObjectStore" />
-    <spring:bean id="objectStore2" class="org.mule.runtime.core.util.store.PartitionedPersistentObjectStore" />
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.PartitionedPersistentObjectStore" />
+    <spring:bean id="objectStore2" class="org.mule.runtime.core.api.store.PartitionedPersistentObjectStore" />
 
     <flow name="customProcessorInFlow">
         <custom-processor class="org.mule.test.integration.exceptions.ExceptionHandlingTestCase$ExceptionHandlerVerifierProcessor" />

--- a/integration/src/test/resources/org/mule/test/integration/notifications/message-processor-notification-test-flow.xml
+++ b/integration/src/test/resources/org/mule/test/integration/notifications/message-processor-notification-test-flow.xml
@@ -24,7 +24,7 @@
         <notification-listener ref="notificationLogger"/>
     </notifications>
 
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.SimpleMemoryObjectStore"/>
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.SimpleMemoryObjectStore"/>
 
     <flow name="singleMP">
         <logger message="check"/>

--- a/integration/src/test/resources/org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml
+++ b/integration/src/test/resources/org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml
@@ -8,7 +8,7 @@
         http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
 	<spring:bean id="objectStore"
-		class="org.mule.runtime.core.util.store.SimpleMemoryObjectStore" />
+		class="org.mule.runtime.core.api.store.SimpleMemoryObjectStore" />
 
 	<flow name="retryExhausted">
 		<until-successful objectStore-ref="objectStore" maxRetries="1" secondsBetweenRetries="1">

--- a/integration/src/test/resources/org/mule/test/integration/routing/until-successful-exception-strategy-config.xml
+++ b/integration/src/test/resources/org/mule/test/integration/routing/until-successful-exception-strategy-config.xml
@@ -7,7 +7,7 @@
 http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <spring:beans>
-        <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.SimpleMemoryObjectStore"/>
+        <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.SimpleMemoryObjectStore"/>
     </spring:beans>
 
     <flow name="withSplitterAggregatorTest">

--- a/integration/src/test/resources/synchronized-flowref-mule-context-start-config.xml
+++ b/integration/src/test/resources/synchronized-flowref-mule-context-start-config.xml
@@ -5,7 +5,7 @@
       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
 		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.SimpleMemoryObjectStore" />
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.SimpleMemoryObjectStore" />
 
     <flow name="flow1">
         <until-successful maxRetries="0" objectStore-ref="objectStore">

--- a/integration/src/test/resources/until-successful-invalid-wait-test.xml
+++ b/integration/src/test/resources/until-successful-invalid-wait-test.xml
@@ -5,7 +5,7 @@
       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.PartitionedPersistentObjectStore"/>
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.PartitionedPersistentObjectStore"/>
 
     <flow name="invalid">
         <until-successful objectStore-ref="objectStore" secondsBetweenRetries="1" millisBetweenRetries="1000">

--- a/integration/src/test/resources/until-successful-seconds-test.xml
+++ b/integration/src/test/resources/until-successful-seconds-test.xml
@@ -9,7 +9,7 @@
                http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
     <!-- use a persistent object store to pinpoint any Event de/serialization issue -->
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.PartitionedPersistentObjectStore" />
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.PartitionedPersistentObjectStore" />
 
     <custom-processor name="dlq-mp" class="org.mule.test.routing.UntilSuccessfulTestCase$CustomMP"/>
 

--- a/integration/src/test/resources/until-successful-test.xml
+++ b/integration/src/test/resources/until-successful-test.xml
@@ -9,7 +9,7 @@
                http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
     <!-- use a persistent object store to pinpoint any Event de/serialization issue -->
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.PartitionedPersistentObjectStore" />
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.PartitionedPersistentObjectStore" />
 
     <custom-processor name="dlq-mp" class="org.mule.test.routing.UntilSuccessfulTestCase$CustomMP"/>
 

--- a/integration/src/test/resources/until-successful-with-splitter.xml
+++ b/integration/src/test/resources/until-successful-with-splitter.xml
@@ -5,7 +5,7 @@
       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
-    <spring:bean id="objectStore" class="org.mule.runtime.core.util.store.SimpleMemoryObjectStore" />
+    <spring:bean id="objectStore" class="org.mule.runtime.core.api.store.SimpleMemoryObjectStore" />
 
     <flow name="withSplitter">
         <set-payload value="#[mel:['a','b']]" />


### PR DESCRIPTION
_ Moving org.mule.runtime.core.util.xa to internal/api
_ Moving org.mule.runtime.core.util.store to internal/api
_ Moving org.mule.runtime.core.util.queue to internal/api