### PR TITLE
MULE-11876: Provide a standard way to build a BindingContext from an

### DIFF
--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -363,16 +363,16 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
     @Override
     public void before(ComponentLocation location, Map<String, Object> parameters, InterceptionEvent event) {
       try {
-        expressionEvaluator.evaluate("variables.addedVar", event.asBindingContext());
+        expressionEvaluator.evaluate("addedVar", event.asBindingContext());
       } catch (ExpressionRuntimeException e) {
         assertThat(e.getMessage(), containsString("Unable to resolve reference of addedVar"));
       }
 
       event.addVariable("addedVar", "value1");
-      assertThat(expressionEvaluator.evaluate("variables.addedVar", event.asBindingContext()).getValue(), is("value1"));
+      assertThat(expressionEvaluator.evaluate("addedVar", event.asBindingContext()).getValue(), is("value1"));
 
       event.addVariable("addedVar", "value2");
-      assertThat(expressionEvaluator.evaluate("variables.addedVar", event.asBindingContext()).getValue(), is("value2"));
+      assertThat(expressionEvaluator.evaluate("addedVar", event.asBindingContext()).getValue(), is("value2"));
     }
 
   }


### PR DESCRIPTION
InterceptionEvent
* Fix in DW (https://github.com/mulesoft/data-weave/issues/154), remove
workaround