### PR TITLE
MULE-13045 - Avoid passing the FlowConstruct around just to get the name of the flow

### DIFF
--- a/integration/src/test/java/org/mule/test/el/ExpressionLanguageConfigTestCase.java
+++ b/integration/src/test/java/org/mule/test/el/ExpressionLanguageConfigTestCase.java
@@ -69,14 +69,14 @@ public class ExpressionLanguageConfigTestCase extends AbstractIntegrationTestCas
   @Test
   public void testExpressionLanguageGlobalFunctionUsingMessageContext() throws Exception {
     assertEquals("123appended", el.evaluate("mel:appendPayload()", eventBuilder().message(of("123")).build(),
-                                            getTestFlow(muleContext))
+                                            getTestFlow(muleContext).getLocation())
         .getValue());
   }
 
   @Test
   public void testExpressionLanguageGlobalFunctionUsingMessageContextAndImport() throws Exception {
     assertEquals("321", el.evaluate("mel:reversePayload()", eventBuilder().message(of("123")).build(),
-                                    getTestFlow(muleContext))
+                                    getTestFlow(muleContext).getLocation())
         .getValue());
   }
 

--- a/integration/src/test/java/org/mule/test/integration/SchedulerInitialStateTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/SchedulerInitialStateTestCase.java
@@ -6,14 +6,15 @@
  */
 package org.mule.test.integration;
 
-import static org.mule.runtime.api.deployment.management.ComponentInitialStateManager.SERVICE_ID;
-import static org.mule.test.allure.AllureConstants.SchedulerServiceFeature.SCHEDULER_SERVICE;
-import static org.mule.test.allure.AllureConstants.SchedulerServiceFeature.SchedulerServiceStory.SOURCE_MANAGEMENT;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
+import static org.mule.runtime.api.deployment.management.ComponentInitialStateManager.SERVICE_ID;
+import static org.mule.runtime.dsl.api.component.config.ComponentLocationUtils.getFlowNameFrom;
+import static org.mule.test.allure.AllureConstants.SchedulerServiceFeature.SCHEDULER_SERVICE;
+import static org.mule.test.allure.AllureConstants.SchedulerServiceFeature.SchedulerServiceStory.SOURCE_MANAGEMENT;
 
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
+
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Stories;
@@ -66,7 +68,7 @@ public class SchedulerInitialStateTestCase extends AbstractIntegrationTestCase {
           @Override
           public boolean mustStartMessageSource(AnnotatedObject component) {
             recordedOnStartMessageSources.add(component);
-            return component.getLocation().getParts().get(0).getPartPath().equals("runningSchedulerOnStartup");
+            return getFlowNameFrom(component.getLocation()).equals("runningSchedulerOnStartup");
           }
         };
       }

--- a/integration/src/test/java/org/mule/test/integration/locator/ConfigurationComponentLocatorTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/locator/ConfigurationComponentLocatorTestCase.java
@@ -6,10 +6,6 @@
  */
 package org.mule.test.integration.locator;
 
-import static org.mule.runtime.api.component.location.Location.builder;
-import static org.mule.runtime.api.source.SchedulerMessageSource.SCHEDULER_MESSAGE_SOURCE_IDENTIFIER;
-import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.CONFIGURATION_COMPONENT_LOCATOR;
-import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.ConfigurationComponentLocatorStory.SEARCH_CONFIGURATION;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -17,6 +13,11 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mule.runtime.api.component.location.Location.builder;
+import static org.mule.runtime.api.source.SchedulerMessageSource.SCHEDULER_MESSAGE_SOURCE_IDENTIFIER;
+import static org.mule.runtime.dsl.api.component.config.ComponentLocationUtils.getFlowNameFrom;
+import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.CONFIGURATION_COMPONENT_LOCATOR;
+import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.ConfigurationComponentLocatorStory.SEARCH_CONFIGURATION;
 
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.Location;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
+
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Stories;
@@ -106,7 +108,7 @@ public class ConfigurationComponentLocatorTestCase extends AbstractIntegrationTe
   public void findAllSchedulers() {
     List<AnnotatedObject> components = muleContext.getConfigurationComponentLocator().find(SCHEDULER_MESSAGE_SOURCE_IDENTIFIER);
     assertThat(components, hasSize(2));
-    assertThat(components.stream().map(component -> component.getLocation().getParts().get(0).getPartPath()).collect(toList()),
+    assertThat(components.stream().map(component -> getFlowNameFrom(component.getLocation())).collect(toList()),
                hasItems("myFlow", "anotherFlow"));
   }
 

--- a/integration/src/test/resources/foreach-test.xml
+++ b/integration/src/test/resources/foreach-test.xml
@@ -106,8 +106,8 @@
             <script:component>
                 <script:script engine="groovy">
                     <![CDATA[
-                    def root = flowVars.rootMessage.payload.value
-                    def key = "key3-" + flowVars.counter
+                    def root = vars.rootMessage.payload.value
+                    def key = "key3-" + vars.counter
                     root.order.items << [(key) : "je"]
                     ]]>
                 </script:script>
@@ -122,9 +122,9 @@
         <foreach>
             <script:component>
                 <script:script engine="groovy">
-                    def loops = flowVars.loops.toInteger()
+                    def loops = vars.loops.toInteger()
                     loops++
-                    flowVars['loops'] = loops + ""
+                    vars['loops'] = loops + ""
                 </script:script>
             </script:component>
         </foreach>

--- a/integration/src/test/resources/org/mule/test/integration/messaging/meps/pattern_In-Only-flow.xml
+++ b/integration/src/test/resources/org/mule/test/integration/messaging/meps/pattern_In-Only-flow.xml
@@ -18,7 +18,7 @@
             <script:script engine="groovy">
                 import org.mule.functional.api.notification.FunctionalTestNotification
 
-                muleContext.fireNotification(new FunctionalTestNotification(event, flowConstruct, src, FunctionalTestNotification.EVENT_RECEIVED));
+                muleContext.fireNotification(new FunctionalTestNotification(event, flow, src, FunctionalTestNotification.EVENT_RECEIVED));
             </script:script>
         </script:component>
     </flow>


### PR DESCRIPTION
* Use `ComponentLocation` instead of `FlowConstruct` to get the name of the flow
* Change `flowVars` binding to `vars`