### PR TITLE
MULE-13213: Remove redundant component path element in routers that now

### DIFF
--- a/integration/src/test/java/org/mule/test/core/context/notification/FlowStackTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/FlowStackTestCase.java
@@ -21,7 +21,6 @@ import org.mule.tck.util.FlowTraceUtils.FlowStackAsyncAsserter;
 import org.mule.test.AbstractIntegrationTestCase;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -270,7 +269,6 @@ public class FlowStackTestCase extends AbstractIntegrationTestCase {
                                            "subFlowDynamicWithChoice/processors/0/route/0/processors/0"));
   }
 
-  @Ignore("MULE-13213")
   @Test
   public void flowStaticWithScatterGather() throws Exception {
     flowRunner("flowStaticWithScatterGather").withPayload("payload").run();
@@ -282,7 +280,6 @@ public class FlowStackTestCase extends AbstractIntegrationTestCase {
                                            "flowStaticWithScatterGather/processors/0/route/1/processors/0"));
   }
 
-  @Ignore("MULE-13213")
   @Test
   public void subFlowStaticWithScatterGather() throws Exception {
     flowRunner("subFlowStaticWithScatterGather").withPayload("payload").run();
@@ -295,7 +292,6 @@ public class FlowStackTestCase extends AbstractIntegrationTestCase {
                                            "subFlowStaticWithScatterGather/processors/0/route/1/processors/0"));
   }
 
-  @Ignore("MULE-13213")
   @Test
   public void flowDynamicWithScatterGather() throws Exception {
     flowRunner("flowDynamicWithScatterGather").withPayload("payload").run();
@@ -307,7 +303,6 @@ public class FlowStackTestCase extends AbstractIntegrationTestCase {
                                            "flowDynamicWithScatterGather/processors/0/route/1/processors/0"));
   }
 
-  @Ignore("MULE-13213")
   @Test
   public void subFlowDynamicWithScatterGather() throws Exception {
     flowRunner("subFlowDynamicWithScatterGather").withPayload("payload").run();

--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
@@ -12,6 +12,7 @@ import static java.util.Optional.of;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.component.ComponentIdentifier.buildFromStringRepresentation;
+import static org.mule.runtime.api.component.TypedComponentIdentifier.builder;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.FLOW;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.INTERCEPTING;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.ON_ERROR;
@@ -20,13 +21,12 @@ import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentT
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.ROUTER;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.SCOPE;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.SOURCE;
-import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.UNKNOWN;
-import static org.mule.runtime.api.component.TypedComponentIdentifier.builder;
 import static org.mule.runtime.api.meta.AbstractAnnotatedObject.LOCATION_KEY;
 import static org.mule.runtime.config.spring.api.dsl.model.ApplicationModel.FLOW_IDENTIFIER;
 import static org.mule.runtime.config.spring.api.dsl.model.ApplicationModel.SUBFLOW_IDENTIFIER;
 import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.CONFIGURATION_COMPONENT_LOCATOR;
 import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.ConfigurationComponentLocationStory.COMPONENT_LOCATION;
+
 import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.meta.AnnotatedObject;
 import org.mule.runtime.core.api.construct.Flow;
@@ -37,7 +37,6 @@ import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
 import org.mule.test.AbstractIntegrationTestCase;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -336,7 +335,6 @@ public class ComponentLocationTestCase extends AbstractIntegrationTestCase {
   }
 
   @Test
-  @Ignore("MULE-13213")
   public void flowWithScatterGather() throws Exception {
     flowRunner("flowWithScatterGather").run();
     waitUntilNotificationsArrived(4);
@@ -348,20 +346,17 @@ public class ComponentLocationTestCase extends AbstractIntegrationTestCase {
     DefaultComponentLocation scatterGatherRoute0 = scatterGatherLocation
         .appendRoutePart()
         .appendLocationPart("0", ROUTE, CONFIG_FILE_NAME, of(100));
-    assertNextProcessorLocationIs(scatterGatherRoute0);
     assertNextProcessorLocationIs(scatterGatherRoute0
         .appendProcessorsPart()
         .appendLocationPart("0", LOGGER, CONFIG_FILE_NAME, of(101)));
     DefaultComponentLocation scatterGatherRouter1 = scatterGatherLocation
         .appendRoutePart()
         .appendLocationPart("1", ROUTE, CONFIG_FILE_NAME, of(103));
-    assertNextProcessorLocationIs(scatterGatherRouter1);
     assertNextProcessorLocationIs(scatterGatherRouter1
         .appendProcessorsPart()
         .appendLocationPart("0", VALIDATION_IS_TRUE, CONFIG_FILE_NAME, of(104)));
     DefaultComponentLocation scatterGatherRouter2 = scatterGatherLocation.appendRoutePart()
         .appendLocationPart("2", ROUTE, CONFIG_FILE_NAME, of(106));
-    assertNextProcessorLocationIs(scatterGatherRouter2);
     assertNextProcessorLocationIs(scatterGatherRouter2
         .appendProcessorsPart()
         .appendLocationPart("0", VALIDATION_IS_FALSE, CONFIG_FILE_NAME, of(107)));

--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/MessageProcessorNotificationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/MessageProcessorNotificationTestCase.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.api.context.notification.MessageProcessorNotification.MESSAGE_PROCESSOR_POST_INVOKE;
+
 import org.mule.functional.api.exception.FunctionalTestException;
 import org.mule.runtime.core.api.context.notification.IntegerAction;
 import org.mule.runtime.core.api.context.notification.MessageProcessorNotification;
@@ -291,13 +292,10 @@ public class MessageProcessorNotificationTestCase extends AbstractMessageProcess
   }
 
   @Test
-  @Ignore("MULE-13213")
   public void roundRobin() throws Exception {
     specificationFactory = () -> new Node()
         .serial(pre()) // round-robin
-        .serial(pre())
         .serial(prePost()) // inner logger
-        .serial(post())
         .serial(post())
         .serial(prePost()) // logger
     ;

--- a/munit-tests/src/test/java/org/mule/test/munit/component/location/MUnitComponentPathTestCase.java
+++ b/munit-tests/src/test/java/org/mule/test/munit/component/location/MUnitComponentPathTestCase.java
@@ -57,7 +57,6 @@ public class MUnitComponentPathTestCase extends MuleArtifactFunctionalTestCase {
                notNullValue());
   }
 
-  @Ignore("MULE-13213")
   @Test
   public void beforeTestComponentLocations() throws Exception {
     assertThat(componentLocator.find(builderFromStringRepresentation("beforeTest").build()).get(),
@@ -82,7 +81,6 @@ public class MUnitComponentPathTestCase extends MuleArtifactFunctionalTestCase {
                notNullValue());
   }
 
-  @Ignore("MULE-13213")
   @Test
   public void testComponentLocations() throws Exception {
     assertThat(componentLocator.find(builderFromStringRepresentation("test").build()).get(),


### PR DESCRIPTION
use <route>