### PR TITLE
MULE-13419: Avoid exporting exception mappings and property editor

### DIFF
--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -91,6 +91,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
+        </dependency>
+
         <!-- DB Drivers -->
         <dependency>
             <groupId>org.apache.derby</groupId>

--- a/munit-tests/pom.xml
+++ b/munit-tests/pom.xml
@@ -57,6 +57,14 @@
             <classifier>mule-service</classifier>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
+        </dependency>
+
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-runner</artifactId>


### PR DESCRIPTION
resources
* Fix: test-runner was including transitive test dependencies as plugins