### PR TITLE
MULE-13408: Fix flaky test `org.mule.test.module.scheduler.cron.CronSchedulerTestCase.test`

### DIFF
--- a/schedulers-tests/src/test/java/org/mule/test/integration/schedule/PollScheduleNotificationTestCase.java
+++ b/schedulers-tests/src/test/java/org/mule/test/integration/schedule/PollScheduleNotificationTestCase.java
@@ -14,14 +14,14 @@ import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
 import org.mule.tck.probe.Prober;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-
 public class PollScheduleNotificationTestCase extends MuleArtifactFunctionalTestCase {
 
-  private Prober prober = new PollingProber(5000, 100l);
+  private Prober prober = new PollingProber(RECEIVE_TIMEOUT, 100l);
 
   @Override
   protected String getConfigFile() {

--- a/schedulers-tests/src/test/java/org/mule/test/integration/schedule/PollScheduleTestCase.java
+++ b/schedulers-tests/src/test/java/org/mule/test/integration/schedule/PollScheduleTestCase.java
@@ -7,7 +7,9 @@
 package org.mule.test.integration.schedule;
 
 
+import static java.lang.Thread.sleep;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 
 import org.mule.functional.api.component.EventCallback;
@@ -23,11 +25,11 @@ import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This is a test for poll with schedulers. It validates that the polls can be executed, stopped, run.
@@ -73,9 +75,9 @@ public class PollScheduleTestCase extends MuleArtifactFunctionalTestCase {
 
     int fooElementsAfterStopping = foo.size();
 
-    waitForPollElements();
+    sleep(2000);
 
-    assertThat(foo.size(), is(fooElementsAfterStopping));
+    assertThat(foo, hasSize(fooElementsAfterStopping));
 
     startSchedulers();
     runSchedulersOnce();
@@ -86,12 +88,6 @@ public class PollScheduleTestCase extends MuleArtifactFunctionalTestCase {
       return true;
     }));
   }
-
-  private void waitForPollElements() throws InterruptedException {
-    Thread.sleep(2000);
-  }
-
-
 
   private boolean checkCollectionValues(List<String> coll, String value) {
     for (String s : coll) {

--- a/schedulers-tests/src/test/java/org/mule/test/integration/schedule/RunningScheduleTestCase.java
+++ b/schedulers-tests/src/test/java/org/mule/test/integration/schedule/RunningScheduleTestCase.java
@@ -7,7 +7,8 @@
 package org.mule.test.integration.schedule;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
@@ -46,9 +47,10 @@ public class RunningScheduleTestCase extends MuleArtifactFunctionalTestCase {
 
     int count = scheduler.getCount();
 
-    Thread.sleep(2000);
-
-    assertEquals(count, scheduler.getCount());
+    new PollingProber(2000, 100).check(new JUnitLambdaProbe(() -> {
+      assertThat(scheduler.getCount(), is(count));
+      return true;
+    }));
   }
 
   private void stopSchedulers() throws MuleException {

--- a/schedulers-tests/src/test/java/org/mule/test/module/scheduler/cron/StoppedCronSchedulerTestCase.java
+++ b/schedulers-tests/src/test/java/org/mule/test/module/scheduler/cron/StoppedCronSchedulerTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.test.module.scheduler.cron;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 
 import org.mule.functional.api.component.EventCallback;
@@ -19,11 +20,11 @@ import org.mule.runtime.core.api.source.MessageSource;
 import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-
-import org.junit.Test;
 
 
 public class StoppedCronSchedulerTestCase extends MuleArtifactFunctionalTestCase {
@@ -39,7 +40,7 @@ public class StoppedCronSchedulerTestCase extends MuleArtifactFunctionalTestCase
   public void test() throws Exception {
     runSchedulersOnce(() -> {
       new PollingProber(RECEIVE_TIMEOUT, 200).check(new JUnitLambdaProbe(() -> {
-        assertThat(foo.size(), greaterThanOrEqualTo(1));
+        assertThat(foo, hasSize(greaterThanOrEqualTo(1)));
         return true;
       }));
       return null;

--- a/schedulers-tests/src/test/java/org/mule/test/module/scheduler/cron/SynchronousSchedulerTestCase.java
+++ b/schedulers-tests/src/test/java/org/mule/test/module/scheduler/cron/SynchronousSchedulerTestCase.java
@@ -7,17 +7,20 @@
 package org.mule.test.module.scheduler.cron;
 
 
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
 
 import org.mule.functional.api.component.EventCallback;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.core.api.InternalEvent;
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.tck.probe.JUnitLambdaProbe;
+import org.mule.tck.probe.PollingProber;
+
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.Test;
 
 /**
  * <p>
@@ -26,7 +29,7 @@ import org.junit.Test;
  */
 public class SynchronousSchedulerTestCase extends MuleArtifactFunctionalTestCase {
 
-  private static List<String> foo = new ArrayList<String>();
+  private static List<String> foo = new ArrayList<>();
 
   @Override
   protected String getConfigFile() {
@@ -35,9 +38,10 @@ public class SynchronousSchedulerTestCase extends MuleArtifactFunctionalTestCase
 
   @Test
   public void test() throws InterruptedException {
-    Thread.sleep(6000);
-
-    assertEquals(1, foo.size());
+    new PollingProber(7000, 100).check(new JUnitLambdaProbe(() -> {
+      assertThat(foo, hasSize(1));
+      return true;
+    }));
   }
 
   public static class Foo implements EventCallback {

--- a/schedulers-tests/src/test/resources/cron-scheduler-config.xml
+++ b/schedulers-tests/src/test/resources/cron-scheduler-config.xml
@@ -16,7 +16,7 @@
     <flow name="pollfoo">
         <scheduler doc:name="watermark">
             <scheduling-strategy>
-                <cron expression="0/1 * * * * ?"/>
+                <cron expression="0/2 * * * * ?"/>
             </scheduling-strategy>
         </scheduler>
         <flow-ref name="echo"/>

--- a/schedulers-tests/src/test/resources/cron-scheduler-stopped-config.xml
+++ b/schedulers-tests/src/test/resources/cron-scheduler-stopped-config.xml
@@ -10,7 +10,7 @@
     <flow name="pollfoo" initialState="stopped">
         <scheduler>
             <scheduling-strategy>
-                <cron expression="0/1 * * * * ?"/>
+                <cron expression="0/2 * * * * ?"/>
             </scheduling-strategy>
         </scheduler>
         <set-payload value="testString"/>

--- a/schedulers-tests/src/test/resources/cron-synchronous-scheduler-config.xml
+++ b/schedulers-tests/src/test/resources/cron-synchronous-scheduler-config.xml
@@ -10,7 +10,7 @@
     <flow name="pollfoo">
         <scheduler>
             <scheduling-strategy>
-                <cron expression="0/1 * * * * ?"/>
+                <cron expression="0/2 * * * * ?"/>
             </scheduling-strategy>
         </scheduler>
         <set-payload value="testString"/>

--- a/schedulers-tests/src/test/resources/log4j2-test.xml
+++ b/schedulers-tests/src/test/resources/log4j2-test.xml
@@ -20,6 +20,7 @@
         <!-- Mule classes -->
         <AsyncLogger name="org.mule" level="WARN"/>
         <AsyncLogger name="com.mulesoft" level="WARN"/>
+        <AsyncLogger name="org.quartz" level="INFO"/>
 
         <AsyncRoot level="INFO">
             <AppenderRef ref="Console"/>


### PR DESCRIPTION
Quartz's cron scheduler has a second precision. That may cause that a
job that has to run every second may run at the end of a given second
and at the beginning of the following seconds, being just a couple of
milliseconds apart from each other.
Since test assumes that a task per second are `tasks one second apart
from each other`, the tests are flaky.

I am changing the cons to run every 2 seconds, so i may assume for tests
that `tasks between one and two seconds apart from each other`