### PR TITLE
MULE-13433: Every exported Mule package must contain api (part6)

### DIFF
--- a/integration/src/test/java/org/mule/test/config/MuleConfigurationTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/MuleConfigurationTestCase.java
@@ -13,14 +13,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mule.runtime.core.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
-
+import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.config.MuleConfiguration;
-import org.mule.runtime.core.api.context.MuleContextBuilder;
 import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
+import org.mule.runtime.core.api.config.MuleConfiguration;
 import org.mule.runtime.core.api.config.builders.DefaultsConfigurationBuilder;
-import org.mule.runtime.core.api.context.DefaultMuleContextBuilder;
 import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
+import org.mule.runtime.core.api.context.MuleContextBuilder;
 import org.mule.tck.config.TestServicesConfigurationBuilder;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
@@ -61,7 +60,7 @@ public class MuleConfigurationTestCase extends AbstractMuleTestCase {
     config.setMaxQueueTransactionFilesSize(500);
     config.setAutoWrapMessageAwareTransform(false);
 
-    MuleContextBuilder contextBuilder = new DefaultMuleContextBuilder();
+    MuleContextBuilder contextBuilder = MuleContextBuilder.builder(APP);
     contextBuilder.setMuleConfiguration(config);
     muleContext = new DefaultMuleContextFactory()
         .createMuleContext(asList(testServicesConfigurationBuilder, new DefaultsConfigurationBuilder()), contextBuilder);

--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ModuleComponentPathTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ModuleComponentPathTestCase.java
@@ -19,13 +19,9 @@ import static org.mule.runtime.api.dsl.DslResolvingContext.getDefault;
 import static org.mule.runtime.config.spring.api.dsl.model.ApplicationModel.FLOW_IDENTIFIER;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.module.extension.api.util.MuleExtensionUtils.createDefaultExtensionManager;
-import io.qameta.allure.junit4.DisplayName;
-import org.junit.Assert;
-import org.junit.Test;
 import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.dsl.DslResolvingContext;
 import org.mule.runtime.api.meta.model.ExtensionModel;
-import org.mule.runtime.core.DefaultMuleContext;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.config.builders.AbstractConfigurationBuilder;
@@ -43,6 +39,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import io.qameta.allure.junit4.DisplayName;
+import org.junit.Assert;
+import org.junit.Test;
 
 @DisplayName("XML Connectors Path generation")
 public class ModuleComponentPathTestCase extends AbstractIntegrationTestCase {
@@ -398,7 +398,7 @@ public class ModuleComponentPathTestCase extends AbstractIntegrationTestCase {
         ExtensionManager extensionManager;
         if (muleContext.getExtensionManager() == null) {
           extensionManager = createDefaultExtensionManager();
-          ((DefaultMuleContext) muleContext).setExtensionManager(extensionManager);
+          muleContext.setExtensionManager(extensionManager);
         }
         extensionManager = muleContext.getExtensionManager();
         initialiseIfNeeded(extensionManager, muleContext);

--- a/integration/src/test/java/org/mule/test/integration/SchedulerInitialStateTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/SchedulerInitialStateTestCase.java
@@ -74,11 +74,6 @@ public class SchedulerInitialStateTestCase extends AbstractIntegrationTestCase {
       }
 
       @Override
-      public boolean isConfigured() {
-        return false;
-      }
-
-      @Override
       public void addServiceConfigurator(ServiceConfigurator serviceConfigurator) {
         // Nothing to do
       }

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mule.functional.junit4.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mule.runtime.config.spring.api.SpringXmlConfigurationBuilderFactory.createConfigurationBuilder;
+import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 import static org.mule.runtime.core.api.context.notification.MuleContextNotification.CONTEXT_STARTED;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.CRITICAL_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_ERROR_IDENTIFIER;
@@ -28,19 +29,16 @@ import static org.mule.runtime.core.api.exception.Errors.Identifiers.UNKNOWN_ERR
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.TYPE_PROPERTY_NAME;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.VERSION;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
-
 import org.mule.extension.http.internal.temporary.HttpConnector;
 import org.mule.extension.socket.api.SocketsExtension;
 import org.mule.runtime.api.dsl.DslResolvingContext;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.meta.model.ExtensionModel;
-import org.mule.runtime.core.DefaultMuleContext;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.config.ConfigurationException;
 import org.mule.runtime.core.api.config.builders.AbstractConfigurationBuilder;
-import org.mule.runtime.core.api.context.DefaultMuleContextBuilder;
 import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
 import org.mule.runtime.core.api.context.MuleContextBuilder;
 import org.mule.runtime.core.api.context.MuleContextFactory;
@@ -202,12 +200,12 @@ public class ErrorHandlingConfigurationFailuresTestCase extends AbstractMuleTest
         defaultExtensionManager.setMuleContext(muleContext);
         defaultExtensionManager.initialise();
         getRequiredExtensions().forEach(defaultExtensionManager::registerExtension);
-        ((DefaultMuleContext) muleContext).setExtensionManager(defaultExtensionManager);
+        muleContext.setExtensionManager(defaultExtensionManager);
       }
     });
     builders.add(createConfigurationBuilder(configuration));
     builders.add(new TestServicesConfigurationBuilder());
-    MuleContextBuilder contextBuilder = new DefaultMuleContextBuilder();
+    MuleContextBuilder contextBuilder = MuleContextBuilder.builder(APP);
     MuleContext muleContext = muleContextFactory.createMuleContext(builders, contextBuilder);
     final AtomicReference<Latch> contextStartedLatch = new AtomicReference<>();
     contextStartedLatch.set(new Latch());

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -105,11 +105,6 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
     builders.add(new ConfigurationBuilder() {
 
       @Override
-      public boolean isConfigured() {
-        return false;
-      }
-
-      @Override
       public void configure(MuleContext muleContext) throws ConfigurationException {
         muleContext.getProcessorInterceptorManager().addInterceptorFactory(() -> new AfterWithCallbackInterceptor());
         muleContext.getProcessorInterceptorManager()


### PR DESCRIPTION
_ Removing org.mule.runtime.core from API