### PR TITLE
MULE-14285 Post interceptors and notifications are not fired when an …

### DIFF
--- a/integration/src/test/resources/org/mule/test/construct/flow-ref.xml
+++ b/integration/src/test/resources/org/mule/test/construct/flow-ref.xml
@@ -94,4 +94,20 @@
         <logger/>
     </flow>
 
+    <flow name="flowRefFlowErrorNotifications">
+        <flow-ref name="errorFlow"/>
+    </flow>
+
+    <flow name="errorFlow">
+        <test:processor throwException="true" exceptionToThrow="java.lang.IllegalStateException"/>
+    </flow>
+
+    <flow name="flowRefSubFlowErrorNotifications">
+        <flow-ref name="errorSubFlow"/>
+    </flow>
+
+    <sub-flow name="errorSubFlow">
+        <test:processor throwException="true" exceptionToThrow="java.lang.IllegalStateException" />
+    </sub-flow>
+
 </mule>


### PR DESCRIPTION
…error occurs in a sub-flow referenced using a flow-ref.