### PR TITLE
MULE-14720: Thread type to be used by scripting component must be

### DIFF
--- a/integration/src/test/java/org/mule/test/routing/ForeachTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/ForeachTestCase.java
@@ -51,7 +51,6 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -351,7 +350,6 @@ public class ForeachTestCase extends AbstractIntegrationTestCase {
     order.put("name", "Ellen");
     order.put("email", "ellen.mail.com");
     order.put("items", items);
-    expectedException.expectCause(is(ConcurrentModificationException.class));
     flowRunner("process-json-update").withPayload(singletonMap("order", order)).run();
   }
 


### PR DESCRIPTION
CPU_INTENSIVE
* Undo workaround included as part of MULE-13217