### PR TITLE
MULE-14800: Review Memory usage in integration tests

### DIFF
--- a/integration/src/test/java/org/mule/runtime/test/integration/lifecycle/ApplicationWithDomainRegistryTestCase.java
+++ b/integration/src/test/java/org/mule/runtime/test/integration/lifecycle/ApplicationWithDomainRegistryTestCase.java
@@ -37,6 +37,7 @@ import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 import org.mule.test.allure.AllureConstants;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,6 +62,18 @@ public class ApplicationWithDomainRegistryTestCase extends AbstractMuleTestCase 
   public void createContexts() throws Exception {
     domainContext = new DomainContextBuilder().build();
     applicationContext = new ApplicationContextBuilder().setDomainContext(domainContext).build();
+  }
+
+  @After
+  public void disposeContexts() {
+    if (domainContext != null) {
+      domainContext.dispose();
+      domainContext = null;
+    }
+    if (applicationContext != null) {
+      applicationContext.dispose();
+      applicationContext = null;
+    }
   }
 
   @Story(OBJECT_REGISTRATION)
@@ -135,6 +148,7 @@ public class ApplicationWithDomainRegistryTestCase extends AbstractMuleTestCase 
         disposingLatch.countDown();
         synchronized (applicationContext) {
           applicationContext.dispose();
+          applicationContext = null;
         }
       });
 

--- a/integration/src/test/java/org/mule/runtime/test/integration/lifecycle/ApplicationWithDomainRegistryTestCase.java
+++ b/integration/src/test/java/org/mule/runtime/test/integration/lifecycle/ApplicationWithDomainRegistryTestCase.java
@@ -37,14 +37,14 @@ import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 import org.mule.test.allure.AllureConstants;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -60,8 +60,9 @@ public class ApplicationWithDomainRegistryTestCase extends AbstractMuleTestCase 
 
   @Before
   public void createContexts() throws Exception {
-    domainContext = new DomainContextBuilder().build();
-    applicationContext = new ApplicationContextBuilder().setDomainContext(domainContext).build();
+    domainContext = new DomainContextBuilder().setContextId(MuleContextLifecycleTestCase.class.getSimpleName()).build();
+    applicationContext = new ApplicationContextBuilder().setContextId(ApplicationWithDomainRegistryTestCase.class.getSimpleName())
+        .setDomainContext(domainContext).build();
   }
 
   @After

--- a/integration/src/test/java/org/mule/runtime/test/integration/lifecycle/MuleContextLifecycleTestCase.java
+++ b/integration/src/test/java/org/mule/runtime/test/integration/lifecycle/MuleContextLifecycleTestCase.java
@@ -94,9 +94,9 @@ public class MuleContextLifecycleTestCase extends AbstractMuleTestCase {
           });
           builders.add(new SimpleConfigurationBuilder(baseRegistry));
         }
-      }.setApplicationResources(new String[] {
-          configFile
-      }).build();
+      }.setApplicationResources(configFile)
+          .setContextId(MuleContextLifecycleTestCase.class.getSimpleName())
+          .build();
       fail(EXPECTED_A_CONTEXT_START_EXCEPTION_EXCEPTION);
     } catch (LifecycleException e) {
       LifecycleObject lifecycleBean = (LifecycleObject) e.getComponent();

--- a/integration/src/test/java/org/mule/runtime/test/integration/properties/DomainPropertiesPlaceHolderPropagationTestCase.java
+++ b/integration/src/test/java/org/mule/runtime/test/integration/properties/DomainPropertiesPlaceHolderPropagationTestCase.java
@@ -65,9 +65,11 @@ public class DomainPropertiesPlaceHolderPropagationTestCase extends AbstractMule
   }
 
   private void configureContexts(String domainConfig, String appConfig) throws Exception {
-    domainContext = new DomainContextBuilder().setDomainConfig(domainConfig).build();
+    domainContext = new DomainContextBuilder().setContextId(DomainPropertiesPlaceHolderPropagationTestCase.class.getSimpleName())
+        .setDomainConfig(domainConfig).build();
     applicationContext =
-        new ApplicationContextBuilder().setApplicationResources(new String[] {appConfig}).setDomainContext(domainContext).build();
+        new ApplicationContextBuilder().setContextId(DomainPropertiesPlaceHolderPropagationTestCase.class.getSimpleName())
+            .setApplicationResources(new String[] {appConfig}).setDomainContext(domainContext).build();
   }
 
   @After

--- a/integration/src/test/java/org/mule/test/config/MuleConfigurationConfigTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/MuleConfigurationConfigTestCase.java
@@ -18,13 +18,13 @@ import org.mule.tck.junit4.AbstractMuleTestCase;
 import java.util.List;
 
 import org.junit.After;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class MuleConfigurationConfigTestCase extends AbstractMuleTestCase {
 
-  @ClassRule
-  public static TestServicesConfigurationBuilder testServicesConfigurationBuilder = new TestServicesConfigurationBuilder();
+  @Rule
+  public TestServicesConfigurationBuilder testServicesConfigurationBuilder = new TestServicesConfigurationBuilder();
 
   private MuleContext muleContext;
 
@@ -37,19 +37,28 @@ public class MuleConfigurationConfigTestCase extends AbstractMuleTestCase {
 
   @Test
   public void configurationQueueTxLogSizeExplicitValue() throws Exception {
-    muleContext = new WithServicesApplicationContextBuilder()
-        .setApplicationResources(new String[] {"org/mule/test/config/configuration-queue-tx-log-size-explict-config.xml"})
+    muleContext = new WithServicesApplicationContextBuilder(testServicesConfigurationBuilder)
+        .setContextId(MuleConfigurationConfigTestCase.class.getSimpleName())
+        .setApplicationResources("org/mule/test/config/configuration-queue-tx-log-size-explict-config.xml")
         .build();
     assertThat(muleContext.getConfiguration().getMaxQueueTransactionFilesSizeInMegabytes(), is(100));
   }
 
   @Test
   public void configurationQueueTxLogSizeDefaultValue() throws Exception {
-    muleContext = new WithServicesApplicationContextBuilder().setApplicationResources(new String[] {}).build();
+    muleContext = new WithServicesApplicationContextBuilder(testServicesConfigurationBuilder)
+        .setContextId(MuleConfigurationConfigTestCase.class.getSimpleName())
+        .setApplicationResources().build();
     assertThat(muleContext.getConfiguration().getMaxQueueTransactionFilesSizeInMegabytes(), is(500));
   }
 
   private static class WithServicesApplicationContextBuilder extends ApplicationContextBuilder {
+
+    private TestServicesConfigurationBuilder testServicesConfigurationBuilder;
+
+    public WithServicesApplicationContextBuilder(TestServicesConfigurationBuilder testServicesConfigurationBuilder) {
+      this.testServicesConfigurationBuilder = testServicesConfigurationBuilder;
+    }
 
     @Override
     protected void addBuilders(List<ConfigurationBuilder> builders) {

--- a/integration/src/test/java/org/mule/test/core/context/notification/ExceptionNotificationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/ExceptionNotificationTestCase.java
@@ -7,12 +7,10 @@
 package org.mule.test.core.context.notification;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNull;
 import static org.mule.runtime.api.notification.ExceptionNotification.EXCEPTION_ACTION;
 
 import org.mule.functional.api.exception.FunctionalTestException;
 import org.mule.functional.listener.ExceptionListener;
-import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.notification.ExceptionNotification;
 import org.mule.runtime.api.notification.IntegerAction;
 
@@ -34,13 +32,14 @@ public class ExceptionNotificationTestCase extends AbstractNotificationTestCase 
   public void doTest() throws Exception {
     ExceptionListener exceptionListener = new ExceptionListener(notificationListenerRegistry);
     expectedException.expectCause(instanceOf(FunctionalTestException.class));
-    Message result = flowRunner("the-service").withPayload(TEST_PAYLOAD).run().getMessage();
-    // processing is async, give time for the exception notificator to run
-    exceptionListener.waitUntilAllNotificationsAreReceived();
+    try {
+      flowRunner("the-service").withPayload(TEST_PAYLOAD).run().getMessage();
+    } finally {
+      // processing is async, give time for the exception notificator to run
+      exceptionListener.waitUntilAllNotificationsAreReceived();
 
-    assertNull(result);
-
-    assertNotifications();
+      assertNotifications();
+    }
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/core/context/notification/PipelineAndAsyncMessageNotificationLogger.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/PipelineAndAsyncMessageNotificationLogger.java
@@ -6,17 +6,22 @@
  */
 package org.mule.test.core.context.notification;
 
+import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.tck.core.context.notification.NotificationLogger;
 
 import java.util.LinkedList;
 import java.util.List;
 
-public class PipelineAndAsyncMessageNotificationLogger implements NotificationLogger {
+public class PipelineAndAsyncMessageNotificationLogger implements NotificationLogger, Disposable {
 
-  protected static LinkedList notifications = new LinkedList();
+  protected LinkedList notifications = new LinkedList();
 
   public List getNotifications() {
     return notifications;
   }
 
+  @Override
+  public void dispose() {
+    notifications.clear();
+  }
 }

--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
@@ -42,6 +42,7 @@ import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
 import org.mule.test.AbstractIntegrationTestCase;
 
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -201,6 +202,14 @@ public class ComponentLocationTestCase extends AbstractIntegrationTestCase {
   @Override
   protected String getConfigFile() {
     return CONFIG_FILE_NAME.get();
+  }
+
+  @After
+  public void clearNotifications() {
+    final ProcessorNotificationStore notificationsStore = getNotificationsStore();
+    if (notificationsStore != null) {
+      notificationsStore.getNotifications().clear();
+    }
   }
 
   @Test

--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ModuleComponentPathTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ModuleComponentPathTestCase.java
@@ -62,6 +62,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.qameta.allure.junit4.DisplayName;
+
+import org.junit.After;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -208,6 +210,13 @@ public class ModuleComponentPathTestCase extends AbstractIntegrationTestCase {
     super.doSetUp();
     listener.setLogSingleNotification(true);
     muleContext.getNotificationManager().addListener(listener);
+  }
+
+  @After
+  public void clearNotifications() {
+    if (listener != null) {
+      listener.getNotifications().clear();
+    }
   }
 
   private Optional<ConfigLine> loadConfigLines(Set<ExtensionModel> extensionModels, InputStream inputStream) {

--- a/integration/src/test/java/org/mule/test/integration/domain/db/DomainTransformerRegistrationTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/domain/db/DomainTransformerRegistrationTestCase.java
@@ -21,7 +21,7 @@ public class DomainTransformerRegistrationTestCase extends DomainFunctionalTestC
 
   private static final String APP1 = "app1";
   private static final String APP2 = "app2";
-  private static final String[] APPLICATION_RESOURCES = new String[] {"domain/domain-transformer-registration-config.xml"};
+  private static final String APPLICATION_RESOURCES = "domain/domain-transformer-registration-config.xml";
 
   @Override
   protected String getDomainConfig() {
@@ -30,8 +30,10 @@ public class DomainTransformerRegistrationTestCase extends DomainFunctionalTestC
 
   @Override
   public ApplicationConfig[] getConfigResources() {
-    return new ApplicationConfig[] {new ApplicationConfig(APP1, APPLICATION_RESOURCES),
-        new ApplicationConfig(APP2, APPLICATION_RESOURCES)};
+    return new ApplicationConfig[] {
+        new ApplicationConfig(APP1, APPLICATION_RESOURCES),
+        new ApplicationConfig(APP2, APPLICATION_RESOURCES)
+    };
   }
 
   @Test

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlingConfigurationFailuresTestCase.java
@@ -40,6 +40,7 @@ import org.mule.runtime.api.notification.NotificationListenerRegistry;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.config.ConfigurationException;
+import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
 import org.mule.runtime.core.api.config.builders.AbstractConfigurationBuilder;
 import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
 import org.mule.runtime.core.api.context.MuleContextBuilder;
@@ -261,6 +262,9 @@ public class ErrorHandlingConfigurationFailuresTestCase extends AbstractMuleTest
     builders.add(createConfigurationBuilder(configuration));
     builders.add(new TestServicesConfigurationBuilder());
     MuleContextBuilder contextBuilder = MuleContextBuilder.builder(APP);
+    final DefaultMuleConfiguration muleConfiguration = new DefaultMuleConfiguration();
+    muleConfiguration.setId(ErrorHandlingConfigurationFailuresTestCase.class.getSimpleName());
+    contextBuilder.setMuleConfiguration(muleConfiguration);
     MuleContext muleContext = muleContextFactory.createMuleContext(builders, contextBuilder);
     final AtomicReference<Latch> contextStartedLatch = new AtomicReference<>();
     contextStartedLatch.set(new Latch());

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ExceptionHandlingTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ExceptionHandlingTestCase.java
@@ -46,7 +46,7 @@ public class ExceptionHandlingTestCase extends AbstractIntegrationTestCase {
 
   private static FlowExceptionHandler effectiveMessagingExceptionHandler;
   private static CountDownLatch latch;
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ExceptionHandlingTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ExceptionHandlingTestCase.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
+import org.junit.After;
 import org.junit.Test;
 
 public class ExceptionHandlingTestCase extends AbstractIntegrationTestCase {
@@ -55,8 +56,12 @@ public class ExceptionHandlingTestCase extends AbstractIntegrationTestCase {
 
   @Override
   protected void doSetUp() throws Exception {
-    effectiveMessagingExceptionHandler = null;
     queueHandler = new TestConnectorQueueHandler(registry);
+  }
+
+  @After
+  public void after() {
+    effectiveMessagingExceptionHandler = null;
   }
 
   @Test

--- a/integration/src/test/java/org/mule/test/integration/exceptions/OnErrorPropagateTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/OnErrorPropagateTestCase.java
@@ -59,7 +59,7 @@ import io.qameta.allure.Story;
 @Story("On Error Propagate")
 public class OnErrorPropagateTestCase extends AbstractIntegrationTestCase {
 
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Rule
   public ExpectedError expectedError = none();

--- a/integration/src/test/java/org/mule/test/integration/exceptions/RedeliveryExhaustedTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/RedeliveryExhaustedTestCase.java
@@ -45,7 +45,7 @@ import io.qameta.allure.Story;
 public class RedeliveryExhaustedTestCase extends AbstractIntegrationTestCase {
 
   private static final int MAX_REDELIVERY_COUNT = 2;
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Rule
   public ExpectedError expectedError = none();

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryCustomActionTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryCustomActionTestCase.java
@@ -37,18 +37,19 @@ import org.mule.test.integration.interception.ProcessorInterceptorFactoryTestCas
 import org.mule.test.integration.interception.ProcessorInterceptorFactoryTestCase.InterceptionParameters;
 import org.mule.test.runner.RunnerDelegateTo;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -95,8 +96,12 @@ public class ProcessorInterceptorFactoryCustomActionTestCase extends AbstractInt
 
   @Before
   public void before() {
-    getActiveConnections().clear();
     CustomActionInterceptor.actioner = action -> action.proceed();
+  }
+
+  @After
+  public void after() {
+    getActiveConnections().clear();
     HasInjectedAttributesInterceptor.interceptionParameters.clear();
   }
 

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -49,6 +49,7 @@ import org.mule.test.heisenberg.extension.HeisenbergExtension;
 import org.mule.test.heisenberg.extension.exception.HeisenbergException;
 import org.mule.test.heisenberg.extension.model.KillParameters;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,8 +98,8 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
     return objects;
   }
 
-  @Before
-  public void before() {
+  @After
+  public void after() {
     getActiveConnections().clear();
     HasInjectedAttributesInterceptor.interceptionParameters.clear();
     AfterWithCallbackInterceptor.callback = (event, thrown) -> {
@@ -703,7 +704,8 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
 
   public static class AfterWithCallbackInterceptor implements ProcessorInterceptor {
 
-    static BiConsumer<InterceptionEvent, Optional<Throwable>> callback;
+    static BiConsumer<InterceptionEvent, Optional<Throwable>> callback = (event, thrown) -> {
+    };
 
     @Override
     public void after(ComponentLocation location, InterceptionEvent event, Optional<Throwable> thrown) {

--- a/integration/src/test/java/org/mule/test/integration/messaging/meps/InOnlyOptionalOutTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/messaging/meps/InOnlyOptionalOutTestCase.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 public class InOnlyOptionalOutTestCase extends AbstractIntegrationTestCase {
 
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Override
   protected void doSetUp() throws Exception {

--- a/integration/src/test/java/org/mule/test/integration/messaging/meps/InOnlyOutOnlyTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/messaging/meps/InOnlyOutOnlyTestCase.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 public class InOnlyOutOnlyTestCase extends AbstractIntegrationTestCase {
 
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/integration/messaging/meps/InOutOutOnlyTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/messaging/meps/InOutOutOnlyTestCase.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 public class InOutOutOnlyTestCase extends AbstractIntegrationTestCase {
 
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/integration/routing/inbound/IdempotentRouterWithFilterTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/routing/inbound/IdempotentRouterWithFilterTestCase.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 public class IdempotentRouterWithFilterTestCase extends AbstractIntegrationTestCase {
 
-  private static TestConnectorQueueHandler queueHandler;
+  private TestConnectorQueueHandler queueHandler;
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/routing/UntilSuccessfulTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/UntilSuccessfulTestCase.java
@@ -62,6 +62,13 @@ public class UntilSuccessfulTestCase extends AbstractIntegrationTestCase {
     targetMessageProcessor = getFromFlow(locator, "target-mp");
   }
 
+  @Override
+  protected void doTearDown() throws Exception {
+    CustomMP.clearCount();
+
+    super.doTearDown();
+  }
+
   @Test
   public void defaultConfiguration() throws Exception {
     final String payload = RandomStringUtils.randomAlphanumeric(20);

--- a/integration/src/test/java/org/mule/test/service/scheduler/SchedulerServiceTestCase.java
+++ b/integration/src/test/java/org/mule/test/service/scheduler/SchedulerServiceTestCase.java
@@ -184,7 +184,9 @@ public class SchedulerServiceTestCase extends AbstractIntegrationTestCase {
 
     @Override
     public void initialise() throws InitialisationException {
-      scheduler = schedulerService.cpuLightScheduler();
+      if (scheduler == null) {
+        scheduler = schedulerService.cpuLightScheduler();
+      }
     }
 
     @Override


### PR DESCRIPTION
* Replace static references so objects are not kept in memory
* Fix some error handling test cases that were not testing properly
* Add id to generated contexts so that if a leaked one is found, it can be identified where it was created