### PR TITLE
MULE-16872: Async in a transaction executes in the same thread as the

### DIFF
--- a/integration/src/test/java/org/mule/test/routing/AsyncTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/AsyncTestCase.java
@@ -130,7 +130,7 @@ public class AsyncTestCase extends AbstractIntegrationTestCase {
         (Startable) (locator.find(Location.builderFromStringRepresentation("with-source-tx").build())).get();
     withSourceTx.start();
 
-    assertThat(queueHandler.read("asyncDispatched", 1000), not(nullValue()));
+    assertThat(queueHandler.read("asyncDispatched", RECEIVE_TIMEOUT), not(nullValue()));
     assertThat(queueHandler.read("asyncRunning", 1000), not(nullValue()));
   }
 


### PR DESCRIPTION
* fix test