### PR TITLE
MULE-17577: Fix FlowConfigurationFailuresTestCase flaky test

### DIFF
--- a/integration/src/test/java/org/mule/test/validation/FlowConfigurationFailuresTestCase.java
+++ b/integration/src/test/java/org/mule/test/validation/FlowConfigurationFailuresTestCase.java
@@ -11,16 +11,14 @@ import static org.junit.rules.ExpectedException.none;
 import static org.mule.test.allure.AllureConstants.MuleDsl.MULE_DSL;
 import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
 
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import org.mule.runtime.core.api.config.ConfigurationException;
 import org.mule.test.integration.AbstractConfigurationFailuresTestCase;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 @Feature(MULE_DSL)
 @Story(DSL_VALIDATION_STORY)
@@ -30,7 +28,6 @@ public class FlowConfigurationFailuresTestCase extends AbstractConfigurationFail
   public ExpectedException expectedException = none();
 
   @Test
-  @Ignore("MULE-17577")
   public void showFlowNameUsingInvalidCharacter() throws Exception {
     expectedException.expect(ConfigurationException.class);
     expectedException


### PR DESCRIPTION
- Reactivating potential flaky test to monitor it closely since it has
no been possible to identify its flakiness nature