### PR TITLE
MULE-16461: Remove `concatMap` in XML SDK chain execution

### DIFF
--- a/integration/src/test/resources/org/mule/test/integration/exceptions/log-check-xml-module-config.xml
+++ b/integration/src/test/resources/org/mule/test/integration/exceptions/log-check-xml-module-config.xml
@@ -41,8 +41,7 @@
                         Element               : xmlSdkOperationErrorNested/processors/0 @ LogCheckXmlModuleTestCase#runXmlSdkOperationErrorNested:org/mule/test/integration/exceptions/log-check-xml-module-config.xml:35
                         Element XML           : <module-using-sc:proxy-raise-error-op></module-using-sc:proxy-raise-error-op>
                         Error type            : MODULE-USING-CORE:RAISED
-                        FlowStack             : at module-using-core:raise-error-op
-                                                at module-using-sc:proxy-raise-error-op
+                        FlowStack             : at module-using-sc:proxy-raise-error-op
                                                 at xmlSdkOperationErrorNested
                         Payload               : null
                         Payload Type          : null


### PR DESCRIPTION
* Revert change in test done in previous commit