### PR TITLE
MULE-17757: Migrate uses of

### DIFF
--- a/integration/src/test/java/org/mule/test/integration/AbstractConfigurationFailuresTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/AbstractConfigurationFailuresTestCase.java
@@ -14,19 +14,9 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.config.api.SpringXmlConfigurationBuilderFactory.createConfigurationBuilder;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 import static org.mule.runtime.core.api.context.notification.MuleContextNotification.CONTEXT_STARTED;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.TYPE_PROPERTY_NAME;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.VERSION;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-
-import javax.inject.Inject;
-
-import org.junit.Rule;
 
 import org.mule.runtime.api.dsl.DslResolvingContext;
 import org.mule.runtime.api.exception.MuleException;
@@ -49,6 +39,17 @@ import org.mule.tck.config.TestServicesConfigurationBuilder;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.test.integration.exceptions.ErrorHandlingConfigurationFailuresTestCase;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.inject.Inject;
+
+import org.junit.Rule;
+
 
 public abstract class AbstractConfigurationFailuresTestCase extends AbstractMuleTestCase {
 
@@ -67,8 +68,7 @@ public abstract class AbstractConfigurationFailuresTestCase extends AbstractMule
       @Override
       protected void doConfigure(MuleContext muleContext) throws Exception {
         DefaultExtensionManager defaultExtensionManager = new DefaultExtensionManager();
-        defaultExtensionManager.setMuleContext(muleContext);
-        defaultExtensionManager.initialise();
+        initialiseIfNeeded(defaultExtensionManager, muleContext);
         getRequiredExtensions().forEach(defaultExtensionManager::registerExtension);
         muleContext.setExtensionManager(defaultExtensionManager);
       }

--- a/performance/src/main/java/org/mule/test/AbstractFlowBenchmark.java
+++ b/performance/src/main/java/org/mule/test/AbstractFlowBenchmark.java
@@ -14,9 +14,7 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.construct.Flow.builder;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.BLOCKING;
-import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.privileged.registry.LegacyRegistryUtils.registerObject;
-import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.openjdk.jmh.annotations.Scope.Benchmark;
 import static org.openjdk.jmh.infra.Blackhole.consumeCPU;
 
@@ -238,8 +236,6 @@ public abstract class AbstractFlowBenchmark extends AbstractBenchmark {
                                         new PassThroughInvocationHandler(schedulerService)));
         DefaultExpressionLanguageFactoryService weaveExpressionExecutor = new WeaveDefaultExpressionLanguageFactoryService(null);
         registerObject(muleContext, weaveExpressionExecutor.getName(), weaveExpressionExecutor);
-
-        registerObject(muleContext, OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
       }
     });
     builderList.add(new DefaultsConfigurationBuilder());


### PR DESCRIPTION
`MessagingExceptionResolver#resolve(MessagingException, MuleContext)`

* Partial revert of MULE-16371