### PR TITLE
MULE-17894: Integration test

### DIFF
--- a/integration/src/test/java/org/mule/test/integration/routing/outbound/UntilSuccessfulRetryExhaustedTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/routing/outbound/UntilSuccessfulRetryExhaustedTestCase.java
@@ -7,18 +7,16 @@
 package org.mule.test.integration.routing.outbound;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.fail;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.UntilSuccessfulStory.UNTIL_SUCCESSFUL;
 
 import org.mule.runtime.api.notification.ExceptionNotificationListener;
 import org.mule.runtime.api.util.concurrent.Latch;
-import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.extension.api.error.MuleErrors;
+import org.mule.tck.junit4.matcher.ErrorTypeMatcher;
 import org.mule.test.AbstractIntegrationTestCase;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.qameta.allure.Feature;
@@ -38,10 +36,16 @@ public class UntilSuccessfulRetryExhaustedTestCase extends AbstractIntegrationTe
     final Latch exceptionStrategyCalledLatch = new Latch();
     notificationListenerRegistry
         .registerListener((ExceptionNotificationListener) notification -> exceptionStrategyCalledLatch.release());
-    flowRunner("retryExhausted").withPayload("message").run();
+    flowRunner("retryExhaustedCausedByUntypedError").withPayload("message").run();
     if (!exceptionStrategyCalledLatch.await(10000, MILLISECONDS)) {
       fail("exception strategy was not executed");
     }
+  }
+
+  @Test
+  public void onRetryExhaustedErrorTypeMustBeRetryExhausted() throws Exception {
+    flowRunner("retryExhaustedCausedByConnectivityError").withPayload("message")
+        .runExpectingException(ErrorTypeMatcher.errorType(MuleErrors.RETRY_EXHAUSTED));
   }
 
 }

--- a/integration/src/test/resources/org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml
+++ b/integration/src/test/resources/org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml
@@ -8,7 +8,7 @@
     <object name="objectStore"
             class="org.mule.runtime.api.store.SimpleMemoryObjectStore"/>
 
-    <flow name="retryExhausted">
+    <flow name="retryExhaustedCausedByUntypedError">
         <async>
             <try>
                 <until-successful maxRetries="1" millisBetweenRetries="1000">
@@ -19,6 +19,14 @@
                 </error-handler>
             </try>
         </async>
+    </flow>
+
+    <flow name="retryExhaustedCausedByConnectivityError">
+        <try>
+            <until-successful maxRetries="1" millisBetweenRetries="10">
+                <test:processor throwException="true" exceptionToThrow="org.mule.runtime.api.connection.ConnectionException" exceptionText="Connection refused"/>
+            </until-successful>
+        </try>
     </flow>
 
 </mule>


### PR DESCRIPTION
In order to check that the RETRY_EXHAUSTED error type is no longer replaced by a processor exception's error type, the test now throws a ConnectionException that maps to an ErrorType.