### PR TITLE
MULE-18040: Scatter-Gather router does not honor route order in

### DIFF
--- a/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
@@ -8,7 +8,9 @@
 package org.mule.test.routing;
 
 import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.ConcurrentHashMap.newKeySet;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -46,13 +48,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import io.qameta.allure.Description;
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
 
 @Feature(ROUTERS)
 @Story(SCATTER_GATHER)
@@ -232,7 +236,7 @@ public class ScatterGatherRouterTestCase extends AbstractIntegrationTestCase {
   }
 
   @Test
-  @Description("The resulting Map<String, Message result maintains the correct data-type for each Message.")
+  @Description("The resulting Map<String, Message> result maintains the correct data-type for each Message.")
   public void returnsCorrectDataType() throws Exception {
     Message response = flowRunner("dataType").withMediaType(JSON).run().getMessage();
     assertThat(response.getPayload().getValue(), is(Matchers.instanceOf(Map.class)));
@@ -241,6 +245,19 @@ public class ScatterGatherRouterTestCase extends AbstractIntegrationTestCase {
     assertThat(messageList.get("0").getPayload().getDataType().getMediaType(), is(TEXT));
     assertThat(messageList.get("1").getPayload().getDataType().getMediaType(), is(ANY));
     assertThat(messageList.get("2").getPayload().getDataType().getMediaType(), is(ANY));
+  }
+
+  @Test
+  @Description("The resulting Map<String, Message> is iterable in the same order as the defined routes.")
+  @Issue("MULE-18040")
+  public void resultsInOrder() throws Exception {
+    Message response = flowRunner("resultsInOrder").run().getMessage();
+
+    assertThat(response.getPayload().getValue(), is(Matchers.instanceOf(Map.class)));
+    Map<String, Message> messageList = (Map<String, Message>) response.getPayload().getValue();
+    assertThat(messageList.size(), is(12));
+    assertThat(messageList.values().stream().map(m -> m.getPayload().getValue()).collect(toList()),
+               is(asList("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L")));
   }
 
   public static class ThreadCaptor extends AbstractComponent implements Processor {

--- a/integration/src/test/resources/scatter-gather-test.xml
+++ b/integration/src/test/resources/scatter-gather-test.xml
@@ -363,4 +363,45 @@
         <flow-ref name="testRoutesMap"/>
     </flow>
 
+    <flow name="resultsInOrder">
+        <scatter-gather>
+            <route>
+                <set-payload value="A"/>
+            </route>
+            <route>
+                <set-payload value="B"/>
+            </route>
+            <route>
+                <set-payload value="C"/>
+            </route>
+            <route>
+                <set-payload value="D"/>
+            </route>
+            <route>
+                <set-payload value="E"/>
+            </route>
+            <route>
+                <set-payload value="F"/>
+            </route>
+            <route>
+                <set-payload value="G"/>
+            </route>
+            <route>
+                <set-payload value="H"/>
+            </route>
+            <route>
+                <set-payload value="I"/>
+            </route>
+            <route>
+                <set-payload value="J"/>
+            </route>
+            <route>
+                <set-payload value="K"/>
+            </route>
+            <route>
+                <set-payload value="L"/>
+            </route>
+        </scatter-gather>
+    </flow>
+
 </mule>


### PR DESCRIPTION
aggregated response hashmap when there are 12 or more routes defined