### PR TITLE
MULE-18363: Decouple spring bean definition from ComponentAst (#8833)

### DIFF
--- a/integration/src/test/java/org/mule/test/config/ConfigurationAnnotationsTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/ConfigurationAnnotationsTestCase.java
@@ -45,7 +45,9 @@ public class ConfigurationAnnotationsTestCase extends AbstractIntegrationTestCas
     assertThat(getSourceCode((Component) stb),
                is("<string-to-byte-array-transformer name=\"StringtoByteArray\" doc:name=\"stb-transformer\">"
                    + lineSeparator() + "<annotations>" + lineSeparator()
-                   + "<doc:description>Convert a String to a Byte Array</doc:description>" + lineSeparator()
+                   + "<doc:description>"
+                   + "<![CDATA[" + lineSeparator() + "Convert a String to a Byte Array" + lineSeparator() + "]]>" +
+                   "</doc:description>" + lineSeparator()
                    + "</annotations>" + lineSeparator() + "</string-to-byte-array-transformer>"));
   }
 
@@ -57,7 +59,9 @@ public class ConfigurationAnnotationsTestCase extends AbstractIntegrationTestCas
     assertThat(getDocDescription(flow), is("Main flow"));
     assertThat(getSourceCode(flow),
                is("<flow name=\"Bridge\" doc:name=\"Bridge flow\">" + lineSeparator() + "<annotations>"
-                   + lineSeparator() + "<doc:description>Main flow</doc:description>" + lineSeparator()
+                   + lineSeparator() + "<doc:description>"
+                   + "<![CDATA[" + lineSeparator() + "Main flow" + lineSeparator() + "]]>"
+                   + "</doc:description>" + lineSeparator()
                    + "</annotations>" + lineSeparator() + "<logger doc:name=\"echo\">" + "</logger>"
                    + lineSeparator() + "</flow>"));
   }

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -95,24 +95,22 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   @Test
   public void operationParameters() throws Exception {
     flowRunner("killFromPayload").withPayload("T-1000").withVariable("goodbye", "Hasta la vista, baby").run();
-
   }
 
   @Test
   public void resolvedConfigOperationParameters() throws Exception {
     flowRunner("die").run();
-
   }
 
   @Test
   public void resolvedComplexParametersOperationParameters() throws Exception {
     flowRunner("killWithCustomMessage").withVariable("goodbye", "Hasta la vista, baby").run();
-
   }
 
   @Test
   @Description("The errorType set by an operation is preserved if an interceptor is applied")
   public void failingOperationErrorTypePreserved() throws Exception {
+    expectedError.expectErrorType("TEST", "EXPECTED").expectCause(sameInstance(THROWN));
     expectedError.expectErrorType("HEISENBERG", "CONNECTIVITY").expectCause(sameInstance(THROWN));
     flowRunner("callGusFring").run();
   }
@@ -121,7 +119,6 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   @Test
   public void scOperation() throws Exception {
     flowRunner("scOperation").run();
-
   }
 
   @Description("Smart Connector simple operation with parameters")
@@ -129,7 +126,6 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   public void scEchoOperation() throws Exception {
     final String variableValue = "echo message for the win";
     flowRunner("scEchoOperation").withVariable("variable", variableValue).run();
-
   }
 
   @Description("Smart Connector simple operation with parameters through flow-ref")
@@ -137,31 +133,32 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   public void scEchoOperationFlowRef() throws Exception {
     final String variableValue = "echo message for the win";
     flowRunner("scEchoOperationFlowRef").withVariable("variable", variableValue).run();
-
   }
 
   @Description("Smart Connector that uses a Smart Connector operation without parameters")
   @Test
   public void scUsingScOperation() throws Exception {
     flowRunner("scUsingScOperation").run();
-
   }
 
   @Test
   @Description("Errors in sub-flows are handled correctly")
   public void failingSubFlow() throws Exception {
+    expectedError.expectErrorType("TEST", "EXPECTED").expectCause(sameInstance(THROWN));
     flowRunner("flowWithFailingSubFlowRef").run();
   }
 
   @Test
   @Description("Processors in error handlers are intercepted correctly")
   public void errorHandler() throws Exception {
+    expectedError.expectErrorType("TEST", "EXPECTED").expectCause(sameInstance(THROWN));
     flowRunner("flowFailingWithErrorHandler").run();
   }
 
   @Test
   @Description("Processors in global error handlers are intercepted correctly")
   public void globalErrorHandler() throws Exception {
+    expectedError.expectErrorType("TEST", "EXPECTED").expectCause(sameInstance(THROWN));
     flowRunner("flowFailing").run();
   }
 
@@ -214,6 +211,7 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   @Test
   @Description("Processors in global error handlers are intercepted correctly when error is in referenced flow")
   public void globalErrorHandlerWithFlowRef() throws Exception {
+    expectedError.expectErrorType("TEST", "EXPECTED").expectCause(sameInstance(THROWN));
     flowRunner("flowWithFailingFlowRef").run();
   }
 

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -31,7 +31,6 @@ import static org.mule.test.heisenberg.extension.HeisenbergOperations.CALL_GUS_M
 
 import org.mule.extension.http.api.request.validator.ResponseValidatorException;
 import org.mule.functional.api.exception.ExpectedError;
-import org.mule.functional.api.exception.FunctionalTestException;
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -517,7 +516,7 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
   @Test
   @Description("Errors in sub-flows are handled correctly")
   public void failingSubFlow() throws Exception {
-    expectedError.expectCause(instanceOf(FunctionalTestException.class));
+    expectedError.expectErrorType("TEST", "EXPECTED");
 
     try {
       flowRunner("flowWithFailingSubFlowRef").run();
@@ -532,8 +531,8 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
 
       InterceptionParameters failParameter = interceptionParameters.get(1);
 
-      assertThat(failParameter.getParameters().keySet(), containsInAnyOrder("throwException"));
-      assertThat(failParameter.getParameters().get("throwException").resolveValue(), is("true"));
+      assertThat(failParameter.getParameters().keySet(), containsInAnyOrder("type"));
+      assertThat(failParameter.getParameters().get("type").resolveValue(), is("TEST:EXPECTED"));
 
       // the 3rd one is for the global error handler, it is tested separately
     }
@@ -542,14 +541,14 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
   @Test
   @Description("Processors in error handlers are intercepted correctly")
   public void errorHandler() throws Exception {
-    expectedError.expectCause(instanceOf(FunctionalTestException.class));
+    expectedError.expectErrorType("TEST", "EXPECTED");
 
     AtomicBoolean afterCallbackCalledForFailingMP = new AtomicBoolean(false);
     AtomicBoolean afterCallbackCalledForErrorHandlingMp = new AtomicBoolean(false);
 
     AfterWithCallbackInterceptor.callback = (event, thrown) -> {
       if (!afterCallbackCalledForFailingMP.getAndSet(true)) {
-        assertThat(thrown.get(), instanceOf(FunctionalTestException.class));
+        assertThat(thrown.get(), instanceOf(DefaultMuleException.class));
       } else {
         afterCallbackCalledForErrorHandlingMp.set(true);
       }
@@ -573,14 +572,14 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
   @Test
   @Description("Processors in global error handlers are intercepted correctly")
   public void globalErrorHandler() throws Exception {
-    expectedError.expectCause(instanceOf(FunctionalTestException.class));
+    expectedError.expectErrorType("TEST", "EXPECTED");
 
     AtomicBoolean afterCallbackCalledForFailingMP = new AtomicBoolean(false);
     AtomicBoolean afterCallbackCalledForErrorHandlingMp = new AtomicBoolean(false);
 
     AfterWithCallbackInterceptor.callback = (event, thrown) -> {
       if (!afterCallbackCalledForFailingMP.getAndSet(true)) {
-        assertThat(thrown.get(), instanceOf(FunctionalTestException.class));
+        assertThat(thrown.get(), instanceOf(DefaultMuleException.class));
       } else {
         afterCallbackCalledForErrorHandlingMp.set(true);
       }
@@ -734,7 +733,8 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
   @Test
   @Description("Processors in global error handlers are intercepted correctly when error is in referenced flow")
   public void globalErrorHandlerWithFlowRef() throws Exception {
-    expectedError.expectCause(instanceOf(FunctionalTestException.class));
+    expectedError.expectErrorType("TEST", "EXPECTED");
+
 
     AtomicInteger afters = new AtomicInteger(0);
 

--- a/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
+++ b/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
@@ -124,7 +124,7 @@
     </flow>
 
     <flow name="flowFailing">
-        <test:processor throwException="true"/>
+        <raise-error type="TEST:EXPECTED"/>
     </flow>
 
     <flow name="flowRaise">
@@ -132,7 +132,7 @@
     </flow>
 
     <flow name="flowFailingWithErrorHandler">
-        <test:processor throwException="true"/>
+        <raise-error type="TEST:EXPECTED"/>
         <error-handler>
             <on-error-propagate>
                 <logger message="error handled for flow"/>
@@ -149,7 +149,7 @@
     </flow>
 
     <sub-flow name="failing-sub-flow">
-        <test:processor throwException="true"/>
+        <raise-error type="TEST:EXPECTED"/>
     </sub-flow>
 
     <flow name="implicitConfigInNestedScope">


### PR DESCRIPTION
* Addendum: use ComponentAst instead of ComponentModel in
`org.mule.runtime.config.internal.dsl`