### PR TITLE
MULE-17709: Add `error-mapping` information into operations model

### DIFF
--- a/munit-tests/src/test/java/org/mule/test/munit/component/location/MUnitErrorTestCase.java
+++ b/munit-tests/src/test/java/org/mule/test/munit/component/location/MUnitErrorTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.munit.component.location;
+
+import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
+
+import org.junit.Test;
+
+import io.qameta.allure.Issue;
+
+public class MUnitErrorTestCase extends MuleArtifactFunctionalTestCase {
+
+  @Override
+  protected String getConfigFile() {
+    return "org/mule/test/munit/component/error/munit-expected-error.xml";
+  }
+
+  @Test
+  @Issue("MULE-17709")
+  public void testWithExpectedError() throws Exception {
+    // Nothing to do here, just the set up of the test is enough
+  }
+
+}

--- a/munit-tests/src/test/resources/org/mule/test/munit/component/error/munit-expected-error.xml
+++ b/munit-tests/src/test/resources/org/mule/test/munit/component/error/munit-expected-error.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+               http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd">
+
+    <munit:config name="munitConfig"/>
+
+    <munit:test name="test" tags="core,EE" expectedErrorType="APP:EXPECTED">
+        <munit:behavior>
+            <logger/>
+        </munit:behavior>
+        <munit:execution>
+            <raise-error type="APP:EXPECTED"/>
+        </munit:execution>
+        <munit:validation>
+            <logger/>
+        </munit:validation>
+    </munit:test>
+
+</mule>


### PR DESCRIPTION
* Test for MUnit DSL regardin error types