### PR TITLE
MULE-18642: ComponentAst downcasting fails when a BaseComponentAstDecorator is used

### DIFF
--- a/dsl/src/test/java/org/mule/test/config/ast/ParameterAstTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ParameterAstTestCase.java
@@ -183,7 +183,7 @@ public class ParameterAstTestCase extends AbstractMuleContextTestCase {
 
     // TODO MULE-17199 use an ASP parser api
     this.artifactAst = new ApplicationModel(artifactConfig, null, extensionModels, Collections.emptyMap(),
-                                            Optional.empty(), of(componentBuildingDefinitionRegistry),
+                                            Optional.empty(),
                                             uri -> muleContext.getExecutionClassLoader().getResourceAsStream(uri));
   }
 

--- a/dsl/src/test/java/org/mule/test/extension/dsl/AbstractElementModelTestCase.java
+++ b/dsl/src/test/java/org/mule/test/extension/dsl/AbstractElementModelTestCase.java
@@ -35,7 +35,6 @@ import org.mule.runtime.core.api.extension.MuleExtensionModelProvider;
 import org.mule.runtime.core.api.util.xmlsecurity.XMLSecureFactories;
 import org.mule.runtime.core.internal.util.DefaultResourceLocator;
 import org.mule.runtime.dsl.api.ConfigResource;
-import org.mule.runtime.dsl.api.component.config.ComponentConfiguration;
 import org.mule.runtime.dsl.api.xml.XmlNamespaceInfoProvider;
 import org.mule.runtime.dsl.api.xml.parser.ConfigFile;
 import org.mule.runtime.dsl.api.xml.parser.ParsingPropertyResolver;
@@ -107,12 +106,6 @@ public abstract class AbstractElementModelTestCase extends MuleArtifactFunctiona
 
   // Scaffolding
   protected <T extends NamedObject> DslElementModel<T> resolve(ComponentAst component) {
-    Optional<DslElementModel<T>> elementModel = modelResolver.create(component);
-    assertThat(elementModel.isPresent(), is(true));
-    return elementModel.get();
-  }
-
-  protected <T extends NamedObject> DslElementModel<T> resolve(ComponentConfiguration component) {
     Optional<DslElementModel<T>> elementModel = modelResolver.create(component);
     assertThat(elementModel.isPresent(), is(true));
     return elementModel.get();

--- a/dsl/src/test/java/org/mule/test/extension/dsl/ConfigurationBasedDslElementModelSerializerTestCase.java
+++ b/dsl/src/test/java/org/mule/test/extension/dsl/ConfigurationBasedDslElementModelSerializerTestCase.java
@@ -16,7 +16,6 @@ import org.mule.tck.junit4.rule.DynamicPort;
 import java.io.IOException;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.w3c.dom.Element;
@@ -58,7 +57,6 @@ public class ConfigurationBasedDslElementModelSerializerTestCase extends Abstrac
   }
 
   @Test
-  @Ignore("MULE-17197")
   public void serialize() throws Exception {
     XmlDslElementModelConverter converter = XmlDslElementModelConverter.getDefault(this.doc);
 

--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ModuleComponentPathTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ModuleComponentPathTestCase.java
@@ -331,7 +331,6 @@ public class ModuleComponentPathTestCase extends AbstractIntegrationTestCase {
     ArtifactAst toolingApplicationModel = new ApplicationModel(artifactConfigBuilder.build(), null,
                                                                extensionModels, emptyMap(),
                                                                empty(),
-                                                               empty(),
                                                                uri -> {
                                                                  throw new UnsupportedOperationException();
                                                                });

--- a/integration/src/test/java/org/mule/test/integration/locator/ConfigurationComponentLocatorTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/locator/ConfigurationComponentLocatorTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.component.ComponentIdentifier.buildFromStringRepresentation;
 import static org.mule.runtime.api.component.location.Location.builder;
 import static org.mule.runtime.api.source.SchedulerMessageSource.SCHEDULER_MESSAGE_SOURCE_IDENTIFIER;
+import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_MULE_CONFIGURATION;
 import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.CONFIGURATION_COMPONENT_LOCATOR;
 import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.ConfigurationComponentLocatorStory.SEARCH_CONFIGURATION;
 
@@ -152,7 +153,7 @@ public class ConfigurationComponentLocatorTestCase extends AbstractIntegrationTe
                                                      "mySubFlow/processors/0",
                                                      "flowFailing",
                                                      "flowFailing/processors/0",
-                                                     "_muleConfiguration",
+                                                     OBJECT_MULE_CONFIGURATION,
                                                      "globalErrorHandler",
                                                      "globalErrorHandler/0",
                                                      "globalErrorHandler/0/processors/0",

--- a/integration/src/test/java/org/mule/test/integration/locator/LazyInitConfigurationComponentLocatorTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/locator/LazyInitConfigurationComponentLocatorTestCase.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.component.location.Location.builder;
 import static org.mule.runtime.api.component.location.Location.builderFromStringRepresentation;
 import static org.mule.runtime.config.api.SpringXmlConfigurationBuilderFactory.createConfigurationBuilder;
+import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_MULE_CONFIGURATION;
 import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.CONFIGURATION_COMPONENT_LOCATOR;
 import static org.mule.test.allure.AllureConstants.ConfigurationComponentLocatorFeature.ConfigurationComponentLocatorStory.SEARCH_CONFIGURATION;
 
@@ -119,7 +120,7 @@ public class LazyInitConfigurationComponentLocatorTestCase extends AbstractInteg
                                   MY_SUB_FLOW,
                                   MY_SUB_FLOW + "/processors/0",
 
-                                  "_muleConfiguration",
+                                  OBJECT_MULE_CONFIGURATION,
                                   "globalErrorHandler",
                                   "globalErrorHandler/0",
                                   "globalErrorHandler/0/processors/0",


### PR DESCRIPTION
* Part 1 of MULE-17197: Decouple code from ComponentModel implementation