### PR TITLE
DEL-887: Fix tests-components and exclude muleSpringModuleDistroTestVersion in enforcer plugin

### DIFF
--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>test-components</artifactId>
-            <version>${project.version}</version>
+            <version>${muleTestComponentsVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/extensions-xml-support/pom.xml
+++ b/extensions-xml-support/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>test-components</artifactId>
-            <version>${project.version}</version>
+            <version>${muleTestComponentsVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -345,7 +345,7 @@
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>test-components</artifactId>
-            <version>${project.version}</version>
+            <version>${muleTestComponentsVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,10 @@
                         <exclude>org.mule.tools.maven:mule-classloader-model</exclude>
                         <exclude>org.mule.modules:mule-module-cors-kernel</exclude>
                         <exclude>org.mule.tests:test-components</exclude>
+
+                        <exclude>org.mule.modules:mule-spring-module</exclude>
+                        <exclude>org.mule.modules:mule-spring-module-tests</exclude>
+                        <exclude>org.mule.modules:mule-spring-test-plugin</exclude>
                       </excludes>
                     </requireReleaseDeps>
                     <requireReleaseVersion>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>test-components</artifactId>
-            <version>${project.version}</version>
+            <version>${muleTestComponentsVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
- Fix test-components mule dependency to use the property muleTestComponentsVersion in place of the project.version
- Exclude muleSpringModuleDistroTestVersion in enforcer plugin as we can't avoid using a snapshot dep version