### PR TITLE
MULE-18879: Fix flaky test org.mule.shutdown.ValidShutdownTimeoutOneWayTestCase.testSetPayload

### DIFF
--- a/integration/src/test/java/org/mule/shutdown/ValidShutdownTimeoutOneWayTestCase.java
+++ b/integration/src/test/java/org/mule/shutdown/ValidShutdownTimeoutOneWayTestCase.java
@@ -56,9 +56,6 @@ public class ValidShutdownTimeoutOneWayTestCase extends AbstractShutdownTimeoutR
     final Future<?> requestTask = executor.submit(() -> {
       try {
         flowRunner(flowName).withPayload(payload).dispatch();
-
-        Message response = queueHandler.read("response", RECEIVE_TIMEOUT).getMessage();
-        assertThat("Was not able to process message ", getPayloadAsString(response), is(payload));
       } catch (Exception e) {
         throw new MuleRuntimeException(e);
       }
@@ -67,6 +64,9 @@ public class ValidShutdownTimeoutOneWayTestCase extends AbstractShutdownTimeoutR
     // Make sure to give the request enough time to get to the waiting portion of the feed.
     waitLatch.await();
     contextStopLatch.release();
+
+    Message response = queueHandler.read("response", RECEIVE_TIMEOUT).getMessage();
+    assertThat("Was not able to process message", getPayloadAsString(response), is(payload));
 
     muleContext.stop();
 


### PR DESCRIPTION
(cherry picked from commit 4c21a3fa725801e5a0e046ae6f8c4853b9d348a2)