### PR TITLE
MULE-18918: Fix flaky test org.mule.shutdown.ValidShutdownTimeoutRequestResponseTestCase.testExpressionTransformer

### DIFF
--- a/integration/src/test/java/org/mule/shutdown/ValidShutdownTimeoutRequestResponseTestCase.java
+++ b/integration/src/test/java/org/mule/shutdown/ValidShutdownTimeoutRequestResponseTestCase.java
@@ -18,6 +18,8 @@ import org.mule.runtime.http.api.domain.message.request.HttpRequest;
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 import org.mule.service.http.TestHttpClient;
 import org.mule.tck.junit4.rule.SystemProperty;
+import org.mule.tck.probe.JUnitLambdaProbe;
+import org.mule.tck.probe.PollingProber;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -62,10 +64,15 @@ public class ValidShutdownTimeoutRequestResponseTestCase extends AbstractShutdow
   private void doShutDownTest(final String payload, final String url) throws Throwable {
     final Future<?> requestTask = executor.submit(() -> {
       try {
-        HttpRequest request =
-            HttpRequest.builder().uri(url).method(GET).entity(new ByteArrayHttpEntity(payload.getBytes())).build();
-        final HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT * 5, false, null);
-        assertThat("Was not able to process message ", IOUtils.toString(response.getEntity().getContent()), is(payload));
+        new PollingProber().check(new JUnitLambdaProbe(() -> {
+          HttpRequest request =
+              HttpRequest.builder().uri(url).method(GET).entity(new ByteArrayHttpEntity(payload.getBytes())).build();
+          final HttpResponse response =
+              httpClient.send(request, RECEIVE_TIMEOUT * 5, false, null);
+          assertThat(IOUtils.toString(response.getEntity().getContent()), is(payload));
+          return true;
+        }, "Was not able to process message "));
+
       } catch (Exception e) {
         throw new MuleRuntimeException(e);
       }


### PR DESCRIPTION
(cherry picked from commit d72c4c9d4e6b2e711d01917e6a3349670d43889e)