### PR TITLE
MULE-18985: ValueProvider and Metadata should return a failureErrorCo…

### DIFF
--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ComponentValueProviderTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ComponentValueProviderTestCase.java
@@ -314,4 +314,16 @@ public class ComponentValueProviderTestCase extends DeclarationSessionTestCase {
     assertThat(america.getId(), is("America"));
     assertThat(america.getChilds(), hasSize(2));
   }
+
+  @Test
+  public void connectionFailure() {
+    ComponentElementDeclaration elementDeclaration = configLessOPDeclaration(CONFIG_FAILING_CONNECTION_PROVIDER);
+    validateValuesFailure(session, elementDeclaration,
+                          PROVIDED_PARAMETER_NAME,
+                          "Failed to establish connection: org.mule.runtime.api.connection.ConnectionException: Expected connection exception",
+                          "CONNECTION_FAILURE",
+                          "");
+  }
+
+
 }

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ConnectivityTestingTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ConnectivityTestingTestCase.java
@@ -9,8 +9,10 @@ package org.mule.runtime.module.tooling;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configurationDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.connectionDeclaration;
+import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionValidationResult;
 import org.mule.runtime.app.declaration.api.fluent.ArtifactDeclarer;
 
@@ -50,6 +52,14 @@ public class ConnectivityTestingTestCase extends DeclarationSessionTestCase {
     assertThat(connectionValidationResult.getMessage(),
                equalTo(format("Could not perform test connection for configuration: '%s'. Connection provider is not defined",
                               invalidConfigName)));
+  }
+
+  @Test
+  public void testConnectionOnFailingConnectionProvider() {
+    ConnectionValidationResult connectionValidationResult = session.testConnection(CONFIG_FAILING_CONNECTION_PROVIDER);
+    assertThat(connectionValidationResult.isValid(), equalTo(false));
+    assertThat(connectionValidationResult.getMessage(), equalTo("Exception was found trying to test connectivity"));
+    assertThat(connectionValidationResult.getException(), instanceOf(ConnectionException.class));
   }
 
 }

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/DeclarationSessionTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/DeclarationSessionTestCase.java
@@ -15,6 +15,7 @@ import static org.mule.runtime.app.declaration.api.fluent.ElementDeclarer.newArt
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.TEST_EXTENSION_DECLARER;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configurationDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.connectionDeclaration;
+import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.failingConnectionDeclaration;
 import static org.mule.test.infrastructure.maven.MavenTestUtils.getMavenLocalRepository;
 import org.mule.runtime.api.value.ResolvingFailure;
 import org.mule.runtime.api.value.ValueResult;
@@ -39,6 +40,8 @@ public abstract class DeclarationSessionTestCase extends AbstractFakeMuleServerT
   protected static final String EXTENSION_TYPE = "jar";
 
   protected static final String CONFIG_NAME = "dummyConfig";
+  protected static final String CONFIG_FAILING_CONNECTION_PROVIDER = "configNameFailingConnectionProvider";
+
   protected static final String CLIENT_NAME = "client";
   protected static final String PROVIDED_PARAMETER_NAME = "providedParameter";
   protected static final String ERROR_PROVIDED_PARAMETER_NAME = "errorProvidedParameter";
@@ -74,6 +77,9 @@ public abstract class DeclarationSessionTestCase extends AbstractFakeMuleServerT
 
   protected void declareArtifact(ArtifactDeclarer artifactDeclarer) {
     artifactDeclarer.withGlobalElement(configurationDeclaration(CONFIG_NAME, connectionDeclaration(CLIENT_NAME)));
+    artifactDeclarer.withGlobalElement(configurationDeclaration(CONFIG_FAILING_CONNECTION_PROVIDER,
+                                                                failingConnectionDeclaration()));
+
   }
 
   @After

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/SampleDataTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/SampleDataTestCase.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.tooling;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.CUSTOM_ERROR_CODE;
@@ -205,6 +206,14 @@ public class SampleDataTestCase extends DeclarationSessionTestCase {
     assertSampleDataSuccess(elementDeclaration, "client-actingParameter", "dummyConfig");
   }
 
+  @Test
+  public void connectionFailure() {
+    assertSampleDataFailure(configLessOPDeclaration(CONFIG_FAILING_CONNECTION_PROVIDER),
+                            "Failed to establish connection: org.mule.runtime.api.connection.ConnectionException: Expected connection exception",
+                            "org.mule.sdk.api.data.sample.SampleDataException: Failed to establish connection: org.mule.runtime.api.connection.ConnectionException: Expected connection exception",
+                            "CONNECTION_FAILURE");
+  }
+
   private void assertSampleDataSuccess(ComponentElementDeclaration<?> elementDeclaration, String expectedPayload,
                                        Object expectedAttributes) {
     SampleDataResult sampleData = session.getSampleData(elementDeclaration);
@@ -224,7 +233,7 @@ public class SampleDataTestCase extends DeclarationSessionTestCase {
 
     SampleDataFailure sampleDataFailure = sampleData.getFailure().get();
     assertThat(sampleDataFailure.getMessage(), is(expectedMessage));
-    assertThat(sampleDataFailure.getReason(), is(expectedReason));
+    assertThat(sampleDataFailure.getReason(), containsString(expectedReason));
     assertThat(sampleDataFailure.getFailureCode(), is(expectedCode));
   }
 }


### PR DESCRIPTION
…de=CONNECTION_FAILURE when a connection cannot be established/created from the context