### PR TITLE
MULE-18953: Fix flaky test org.mule.test.routing.ParallelForEachWithContextScopesTestCase.parallelForEachWithErrorHandling

### DIFF
--- a/integration/src/test/java/org/mule/test/routing/ParallelForEachWithContextScopesTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/ParallelForEachWithContextScopesTestCase.java
@@ -53,8 +53,8 @@ public class ParallelForEachWithContextScopesTestCase extends AbstractIntegratio
   @Test
   @Issue("MULE-18696")
   @Description("Check that parallel for each is not referencing to the original event prior the error handling")
-  public void parallelForEachWithErorHandling() throws Exception {
-    flowRunner("parallelForEachWithErorHandling").withPayload(FRUIT_LIST).run();
+  public void parallelForEachWithErrorHandling() throws Exception {
+    flowRunner("parallelForEachWithErrorHandling").withPayload(FRUIT_LIST).run();
     // to check last event
     assertEventsUnreferenced();
   }
@@ -71,6 +71,11 @@ public class ParallelForEachWithContextScopesTestCase extends AbstractIntegratio
         return true;
       }
     });
+  }
+
+  @Override
+  protected boolean isGracefulShutdown() {
+    return true;
   }
 
   public static class EventReferenceProcessor implements Processor {

--- a/integration/src/test/resources/routers/parallel-for-each-context-scopes.xml
+++ b/integration/src/test/resources/routers/parallel-for-each-context-scopes.xml
@@ -7,7 +7,7 @@
     <object name="eventReferenceProc"
             class="org.mule.test.routing.ParallelForEachWithContextScopesTestCase$EventReferenceProcessor" />
 
-    <flow name="parallelForEachWithErorHandling">
+    <flow name="parallelForEachWithErrorHandling">
         <parallel-foreach>
             <try>
                 <flow-ref name="eventReferenceProc"/>


### PR DESCRIPTION
(cherry picked from commit 288f3cdcdcb0c2194b3e98a273b65e2bda3a5cff)