### PR TITLE
CMTS-135: INVALID_METADATA_KEY is returned when an acting parameter has an expr…

### DIFF
--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataKeysTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataKeysTestCase.java
@@ -110,7 +110,7 @@ public class MetadataKeysTestCase extends DeclarationSessionTestCase {
     MetadataFailure metadataFailure = metadataResult.getFailures().get(0);
     assertThat(metadataFailure.getMessage(),
                is("Error resolving value for parameter: 'continent' from declaration, it cannot be an EXPRESSION value"));
-    assertThat(metadataFailure.getFailureCode(), is(INVALID_METADATA_KEY));
+    assertThat(metadataFailure.getFailureCode(), is(new FailureCode("INVALID_PARAMETER_VALUE")));
   }
 
   @Test


### PR DESCRIPTION
…ession and the resolver is based on MetadataKeys