### PR TITLE
CMTS-133: If a deployment exception or lifecycle exception is thrown …

### DIFF
--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ComponentValueProviderTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ComponentValueProviderTestCase.java
@@ -33,6 +33,8 @@ import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.simp
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.simpleActingParametersOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.sourceWithMultiLevelValue;
 import static org.mule.runtime.module.tooling.internal.artifact.AbstractParameterResolverExecutor.INVALID_PARAMETER_VALUE;
+import static org.mule.sdk.api.values.ValueResolvingException.UNKNOWN;
+
 import org.mule.runtime.api.value.Value;
 import org.mule.runtime.api.value.ValueResult;
 import org.mule.runtime.app.declaration.api.ComponentElementDeclaration;
@@ -127,6 +129,14 @@ public class ComponentValueProviderTestCase extends DeclarationSessionTestCase {
     validateValuesFailure(session, elementDeclaration, ERROR_PROVIDED_PARAMETER_NAME,
                           "Expected error",
                           CUSTOM_ERROR_CODE);
+  }
+
+  @Test
+  public void internalErrorFromProvider() {
+    ComponentElementDeclaration elementDeclaration = actingParameterOPDeclaration(CONFIG_NAME, "");
+    validateValuesFailure(session, elementDeclaration, INTERNAL_ERROR_PROVIDED_PARAMETER_NAME,
+                          "An error occurred trying to resolve the Values for parameter 'internalErrorProvidedParameter' of component 'actingParameterOP'. Cause: org.mule.tooling.extensions.metadata.internal.value.InternalErrorVP has thrown unexpected exception",
+                          UNKNOWN);
   }
 
   @Test

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/DeclarationSessionTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/DeclarationSessionTestCase.java
@@ -45,6 +45,7 @@ public abstract class DeclarationSessionTestCase extends AbstractFakeMuleServerT
   protected static final String CLIENT_NAME = "client";
   protected static final String PROVIDED_PARAMETER_NAME = "providedParameter";
   protected static final String ERROR_PROVIDED_PARAMETER_NAME = "errorProvidedParameter";
+  protected static final String INTERNAL_ERROR_PROVIDED_PARAMETER_NAME = "internalErrorProvidedParameter";
   protected static final String WITH_ACTING_PARAMETER = "WITH-ACTING-PARAMETER-";
 
   protected DeclarationSession session;

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataKeysTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataKeysTestCase.java
@@ -19,6 +19,7 @@ import static org.mule.runtime.api.metadata.resolving.FailureCode.UNKNOWN;
 import static org.mule.runtime.api.metadata.resolving.MetadataComponent.KEYS;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configLessConnectionLessOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configLessOPDeclaration;
+import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.internalErrorMetadataResolverOP;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.multiLevelOPDeclarationPartialTypeKeys;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.multiLevelShowInDslGroupOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.requiresConfigurationOutputTypeKeyResolverOP;
@@ -195,6 +196,18 @@ public class MetadataKeysTestCase extends DeclarationSessionTestCase {
     assertThat(metadataKeys.getFailures().get(0).getFailingComponent(), is(KEYS));
     assertThat(metadataKeys.getFailures().get(0).getMessage(),
                is("Configuration is not present, a message from resolver"));
+  }
+
+  @Test
+  public void internalErrorInsideResolver() {
+    MetadataResult<MetadataKeysContainer> metadataKeys =
+        session.getMetadataKeys(internalErrorMetadataResolverOP());
+    assertThat(metadataKeys.isSuccess(), is(false));
+    assertThat(metadataKeys.getFailures(), hasSize(1));
+    assertThat(metadataKeys.getFailures().get(0).getFailureCode(), is(UNKNOWN));
+    assertThat(metadataKeys.getFailures().get(0).getFailingComponent(), is(KEYS));
+    assertThat(metadataKeys.getFailures().get(0).getMessage(),
+               is("InternalErrorMetadataResolver has thrown unexpected exception"));
   }
 
 }

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataTypesTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataTypesTestCase.java
@@ -272,7 +272,7 @@ public class MetadataTypesTestCase extends DeclarationSessionTestCase {
     MetadataResult<ComponentMetadataTypesDescriptor> metadataTypes =
         session.resolveComponentMetadata(internalErrorMetadataResolverOP());
     assertThat(metadataTypes.isSuccess(), is(false));
-    assertThat(metadataTypes.getFailures(), IsCollectionWithSize.hasSize(3));
+    assertThat(metadataTypes.getFailures(), hasSize(3));
     for (MetadataFailure metadataFailure : metadataTypes.getFailures()) {
       assertThat(metadataFailure.getFailureCode(), is(UNKNOWN));
       assertThat(metadataFailure.getFailingComponent(), anyOf(is(INPUT), is(OUTPUT_PAYLOAD), is(OUTPUT_ATTRIBUTES)));


### PR DESCRIPTION
…when creating the backed application for a design session the exceptions should be thrown instead of failures with UNKNOWN error code