### PR TITLE
CMTS-140: MetadataKeys and ValueProviders should preserver order of v…

### DIFF
--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ComponentValueProviderTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/ComponentValueProviderTestCase.java
@@ -9,6 +9,9 @@ package org.mule.runtime.module.tooling;
 import static java.time.Instant.now;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
@@ -28,6 +31,7 @@ import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.comp
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configLessConnectionLessOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configLessOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.innerPojo;
+import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.multipleNestedVPsOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.parameterValueProviderWithConfig;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.simpleActingParametersInContainerOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.simpleActingParametersOPDeclaration;
@@ -42,8 +46,6 @@ import org.mule.runtime.app.declaration.api.OperationElementDeclaration;
 import org.mule.runtime.app.declaration.api.ParameterValue;
 import org.mule.runtime.app.declaration.api.fluent.ElementDeclarer;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -54,9 +56,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableMap;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
-
 import org.junit.Test;
 
 public class ComponentValueProviderTestCase extends DeclarationSessionTestCase {
@@ -342,6 +344,17 @@ public class ComponentValueProviderTestCase extends DeclarationSessionTestCase {
     Value america = valueResult.getValues().stream().findFirst().get();
     assertThat(america.getId(), is("America"));
     assertThat(america.getChilds(), hasSize(2));
+  }
+
+  @Test
+  public void preserverOrderValuesResolver() {
+    ComponentElementDeclaration elementDeclaration = multipleNestedVPsOPDeclaration(CONFIG_NAME);
+    ValueResult valueResult = getValueResult(session, elementDeclaration, "levelOne");
+    assertThat(valueResult.isSuccess(), is(true));
+    assertThat(valueResult.getValues(), contains(
+                                                 hasProperty("id", equalTo("ONE")),
+                                                 hasProperty("id", equalTo("TWO")),
+                                                 hasProperty("id", equalTo("THREE"))));
   }
 
   @Test

--- a/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataKeysTestCase.java
+++ b/tooling-support-tests/src/test/java/org/mule/runtime/module/tooling/MetadataKeysTestCase.java
@@ -10,16 +10,18 @@ import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.metadata.resolving.FailureCode.COMPONENT_NOT_FOUND;
-import static org.mule.runtime.api.metadata.resolving.FailureCode.INVALID_METADATA_KEY;
 import static org.mule.runtime.api.metadata.resolving.FailureCode.UNKNOWN;
 import static org.mule.runtime.api.metadata.resolving.MetadataComponent.KEYS;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configLessConnectionLessOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.configLessOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.internalErrorMetadataResolverOP;
+import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.multiLevelOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.multiLevelOPDeclarationPartialTypeKeys;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.multiLevelShowInDslGroupOPDeclaration;
 import static org.mule.runtime.module.tooling.TestExtensionDeclarationUtils.requiresConfigurationOutputTypeKeyResolverOP;
@@ -30,10 +32,12 @@ import org.mule.runtime.api.metadata.MetadataKeysContainer;
 import org.mule.runtime.api.metadata.resolving.FailureCode;
 import org.mule.runtime.api.metadata.resolving.MetadataFailure;
 import org.mule.runtime.api.metadata.resolving.MetadataResult;
+import org.mule.runtime.api.value.ValueResult;
 import org.mule.runtime.app.declaration.api.ComponentElementDeclaration;
 
 import java.util.Set;
 
+import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.Test;
 
@@ -42,6 +46,18 @@ public class MetadataKeysTestCase extends DeclarationSessionTestCase {
   private static final String CONFIG_LESS_CONNECTION_METADATA_RESOLVER = "ConfigLessConnectionLessMetadataResolver";
   private static final String CONFIG_LESS_METADATA_RESOLVER = "ConfigLessMetadataResolver";
   private static final String MULTI_LEVEL_PARTIAL_TYPE_KEYS_OUTPUT_RESOLVER = "MultiLevelPartialTypeKeysOutputTypeResolver";
+  private static final String MULTI_LEVEL_TYPE_KEYS_OUTPUT_RESOLVER = "MultiLevelTypeKeysOutputTypeResolver";
+
+  @Test
+  public void preserveOrder() {
+    ComponentElementDeclaration elementDeclaration = multiLevelOPDeclaration(CONFIG_NAME, null, null);
+    MetadataResult<MetadataKeysContainer> metadataKeys = session.getMetadataKeys(elementDeclaration);
+    assertThat(metadataKeys.isSuccess(), Matchers.is(true));
+
+    Set<MetadataKey> keys = metadataKeys.get().getKeysByCategory().get(MULTI_LEVEL_TYPE_KEYS_OUTPUT_RESOLVER);
+    assertThat(keys, contains(hasProperty("id", equalTo("EUROPE")),
+                              hasProperty("id", equalTo("AMERICA"))));
+  }
 
   @Test
   public void configLessConnectionLessOnOperationMetadataKeys() {


### PR DESCRIPTION
…alues from connector's resolver