### PR TITLE
MULE-17747: Event context termination callbacks not called on (#871)

### DIFF
--- a/integration/src/test/java/org/mule/test/components/FlowExecutionTestCase.java
+++ b/integration/src/test/java/org/mule/test/components/FlowExecutionTestCase.java
@@ -14,19 +14,21 @@ import static org.junit.Assert.fail;
 
 import org.mule.runtime.api.component.execution.ComponentExecutionException;
 import org.mule.runtime.api.component.execution.ExecutableComponent;
-import org.mule.runtime.api.event.Event;
+import org.mule.runtime.api.component.execution.ExecutionResult;
 import org.mule.runtime.api.component.execution.InputEvent;
+import org.mule.runtime.api.event.Event;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.test.AbstractIntegrationTestCase;
-
-import org.junit.Test;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+
+import org.junit.After;
+import org.junit.Test;
 
 public class FlowExecutionTestCase extends AbstractIntegrationTestCase {
 
@@ -49,6 +51,15 @@ public class FlowExecutionTestCase extends AbstractIntegrationTestCase {
   @Override
   protected String getConfigFile() {
     return "org/mule/test/components/flow-execution-config.xml";
+  }
+
+  private ExecutionResult executionResult;
+
+  @After
+  public void after() {
+    if (executionResult != null) {
+      executionResult.complete();
+    }
   }
 
   @Test
@@ -75,8 +86,8 @@ public class FlowExecutionTestCase extends AbstractIntegrationTestCase {
       throws InterruptedException {
     Event resultEvent;
     try {
-      resultEvent = executableComponent.execute(createInputEvent())
-          .get().getEvent();
+      executionResult = executableComponent.execute(createInputEvent()).get();
+      resultEvent = executionResult.getEvent();
       errorIdentifierExpected.ifPresent(error -> fail());
     } catch (ExecutionException e) {
       resultEvent = ((ComponentExecutionException) e.getCause()).getEvent();

--- a/integration/src/test/java/org/mule/test/config/spring/parsers/ProcessorChainRouterTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/spring/parsers/ProcessorChainRouterTestCase.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.junit.After;
 import org.junit.Test;
 
 import io.qameta.allure.Description;
@@ -72,18 +73,29 @@ public class ProcessorChainRouterTestCase extends AbstractIntegrationTestCase im
     return "org/mule/config/spring/parsers/processor-chain-router-config.xml";
   }
 
+  private ExecutionResult executionResult;
+
+  @After
+  public void after() {
+    if (executionResult != null) {
+      executionResult.complete();
+    }
+  }
+
   @Test
   public void executeCompositeRouterUsingInputEvent() throws Exception {
     InputEvent event = createInputEvent();
 
     CompletableFuture<ExecutionResult> completableFuture = compositeChainRouter.execute(event);
-    Event returnedEvent = completableFuture.get().getEvent();
+    executionResult = completableFuture.get();
+    Event returnedEvent = executionResult.getEvent();
     assertProcessorChainResult(returnedEvent);
   }
 
   @Test
   public void executeCompositeRouterUsingEvent() throws Exception {
-    Event flowResultEvent = byPassFlow.execute(createInputEvent()).get().getEvent();
+    executionResult = byPassFlow.execute(createInputEvent()).get();
+    Event flowResultEvent = executionResult.getEvent();
 
     CompletableFuture<Event> completableFuture = compositeChainRouter.execute(flowResultEvent);
     Event returnedEvent = completableFuture.get();
@@ -97,14 +109,16 @@ public class ProcessorChainRouterTestCase extends AbstractIntegrationTestCase im
 
     CompletableFuture<ExecutionResult> completableFuture = flowRefCompositeChainRouter.execute(event);
 
-    Event returnedEvent = completableFuture.get().getEvent();
+    executionResult = completableFuture.get();
+    Event returnedEvent = executionResult.getEvent();
     assertProcessorChainResult(returnedEvent);
   }
 
   @Test
   @Description("Ensure that when composite processor chain is used with more complex/async components such as nested flow-ref there are no dead-locks.")
   public void nestedFlowRefUsingEvent() throws Exception {
-    Event flowResultEvent = byPassFlow.execute(createInputEvent()).get().getEvent();
+    executionResult = byPassFlow.execute(createInputEvent()).get();
+    Event flowResultEvent = executionResult.getEvent();
 
     CompletableFuture<Event> completableFuture = flowRefCompositeChainRouter.execute(flowResultEvent);
 
@@ -118,7 +132,8 @@ public class ProcessorChainRouterTestCase extends AbstractIntegrationTestCase im
 
     CompletableFuture<ExecutionResult> completableFuture = compositeChainRouterError.execute(event);
     try {
-      completableFuture.get().getEvent();
+      executionResult = completableFuture.get();
+      executionResult.getEvent();
       fail();
     } catch (ExecutionException e) {
       ComponentExecutionException componentExecutionException = (ComponentExecutionException) e.getCause();
@@ -134,7 +149,8 @@ public class ProcessorChainRouterTestCase extends AbstractIntegrationTestCase im
     InputEvent event = createInputEvent();
 
     CompletableFuture<ExecutionResult> completableFuture = chainRouter.execute(event);
-    Event returnedEvent = completableFuture.get().getEvent();
+    executionResult = completableFuture.get();
+    Event returnedEvent = executionResult.getEvent();
     assertThat(returnedEvent, notNullValue());
     assertThat(returnedEvent.getMessage().getPayload().getValue(), is("testPayload custom"));
   }
@@ -160,7 +176,8 @@ public class ProcessorChainRouterTestCase extends AbstractIntegrationTestCase im
   public void executeChainFlowConstructDependantComponents() throws Exception {
     InputEvent event = createInputEvent();
     CompletableFuture<ExecutionResult> completableFuture = chainRouterComponents.execute(event);
-    Event returnedEvent = completableFuture.get().getEvent();
+    executionResult = completableFuture.get();
+    Event returnedEvent = executionResult.getEvent();
     assertThat(returnedEvent, notNullValue());
     TestConnectorQueueHandler queueHandler = new TestConnectorQueueHandler(registry);
     assertThat(queueHandler.read("asyncQueue", RECEIVE_TIMEOUT), notNullValue());

--- a/integration/src/test/java/org/mule/test/core/context/notification/ConnectorMessageNotificationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/ConnectorMessageNotificationTestCase.java
@@ -13,6 +13,7 @@ import static org.mule.runtime.http.api.HttpConstants.Method.POST;
 import org.mule.runtime.api.notification.ConnectorMessageNotification;
 import org.mule.runtime.api.notification.IntegerAction;
 import org.mule.runtime.http.api.HttpService;
+import org.mule.runtime.http.api.client.HttpRequestOptions;
 import org.mule.runtime.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -23,7 +24,6 @@ import org.junit.Test;
 public class ConnectorMessageNotificationTestCase extends AbstractNotificationTestCase {
 
   private static final String FLOW_ID = "testFlow";
-  private static final int TIMEOUT = 1000;
 
   @Rule
   public DynamicPort port = new DynamicPort("port");
@@ -41,7 +41,7 @@ public class ConnectorMessageNotificationTestCase extends AbstractNotificationTe
     HttpRequest request =
         HttpRequest.builder().uri(String.format("http://localhost:%s/path", port.getNumber())).method(POST).build();
 
-    httpClient.send(request, TIMEOUT, false, null);
+    httpClient.send(request, HttpRequestOptions.builder().responseTimeout(RECEIVE_TIMEOUT).build());
 
     assertNotifications();
   }

--- a/integration/src/test/java/org/mule/test/el/ExpressionLanguageFunctionsTestCase.java
+++ b/integration/src/test/java/org/mule/test/el/ExpressionLanguageFunctionsTestCase.java
@@ -36,12 +36,12 @@ import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -238,7 +238,7 @@ public class ExpressionLanguageFunctionsTestCase extends AbstractIntegrationTest
 
   }
 
-  public static String sleepForTimeouTest() {
+  public static String sleepForTimeoutTest() {
     // just calling sleep from DW causes the thrown InterruptedException to be unhandled by DW and bubble up.
     try {
       sleep(10000L);

--- a/integration/src/test/java/org/mule/test/routing/AsyncTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/AsyncTestCase.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.mule.runtime.api.util.MuleSystemProperties.MULE_FLOW_TRACE;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
@@ -48,6 +49,10 @@ public class AsyncTestCase extends AbstractIntegrationTestCase {
 
   @Rule
   public SystemProperty maxConcurrency = new SystemProperty("maxConcurrency", "" + MAX_CONCURRENCY);
+
+  @Rule
+  // TODO MULE-17752: Remove this to re-enable flowTrace for this test case
+  public SystemProperty disableFlowStack = new SystemProperty(MULE_FLOW_TRACE, "false");
 
   private TestConnectorQueueHandler queueHandler;
 

--- a/integration/src/test/resources/org/mule/test/el/expression-language-functions-config.xml
+++ b/integration/src/test/resources/org/mule/test/el/expression-language-functions-config.xml
@@ -60,7 +60,7 @@
     </flow>
 
     <flow name="timeoutFlow">
-        <logger level="WARN" message="#[java!org::mule::test::el::ExpressionLanguageFunctionsTestCase::sleepForTimeouTest()]"/>
+        <logger level="WARN" message="#[java!org::mule::test::el::ExpressionLanguageFunctionsTestCase::sleepForTimeoutTest()]"/>
     </flow>
 
     <flow name="failureHandledFlow">

--- a/schedulers-tests/src/test/java/org/mule/test/integration/SchedulerErrorHandlingPropagateTestCase.java
+++ b/schedulers-tests/src/test/java/org/mule/test/integration/SchedulerErrorHandlingPropagateTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.integration;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
+
+import org.mule.functional.api.component.EventCallback;
+import org.mule.runtime.api.component.AbstractComponent;
+import org.mule.runtime.api.util.concurrent.Latch;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.test.AbstractSchedulerTestCase;
+
+import org.junit.Test;
+
+import io.qameta.allure.Story;
+
+@Story(ERROR_HANDLING)
+public class SchedulerErrorHandlingPropagateTestCase extends AbstractSchedulerTestCase {
+
+  private static final int TIMEOUT = 3000;
+  private static Latch latch = new Latch();
+
+  @Override
+  protected String getConfigFile() {
+    return "org/mule/test/integration/scheduler-error-handling-propagate-config.xml";
+  }
+
+  @Test
+  public void errorHandlerIsExecutedInSchedulerFlow() throws Exception {
+    assertThat("Error handler was not executed.", latch.await(TIMEOUT, MILLISECONDS), is(true));
+  }
+
+  public static class VerifyExecutionCallback extends AbstractComponent implements EventCallback {
+
+    @Override
+    public void eventReceived(CoreEvent event, Object component, MuleContext muleContext) throws Exception {
+      latch.release();
+    }
+
+  }
+
+}

--- a/schedulers-tests/src/test/resources/org/mule/test/integration/scheduler-error-handling-propagate-config.xml
+++ b/schedulers-tests/src/test/resources/org/mule/test/integration/scheduler-error-handling-propagate-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+
+    <flow name="handlesErrorsPropagate">
+        <scheduler>
+            <scheduling-strategy>
+                <fixed-frequency frequency="1000" timeUnit="MILLISECONDS" />
+            </scheduling-strategy>
+        </scheduler>
+        <test:processor throwException="true"/>
+        <error-handler>
+            <on-error-propagate>
+                <test:processor>
+                    <test:callback class="org.mule.test.integration.SchedulerErrorHandlingPropagateTestCase$VerifyExecutionCallback"/>
+                </test:processor>
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+
+</mule>


### PR DESCRIPTION
(cherry picked from commit 73645ec31a4b2c8b5f1a8f3ef76bf6d4d2fa926e)