### PR TITLE
Remove maven settings with only public repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 def UPSTREAM_PROJECTS_LIST = [ "Mule-runtime/mule/support/4.2.0" ]
 
 Map pipelineParams = [ "upstreamProjects" : UPSTREAM_PROJECTS_LIST.join(','),
-                       "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
+                       // Comment public setting to get org.mule.runtime:api-annotations:jar:1.1.0-20200709 from private
+                       // repo until it is released in a public repo
+                       // "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
                        "mavenAdditionalArgs" : "-Dmule.scheduler.alwaysShowSchedulerCreationLocation",
                        "additionalConfigFileProviderList" : [configFile(fileId: "mule-runtime-maven-settings-MuleSettings", variable: "org.mule.maven.client.api.SettingsSupplierFactory.userSettings")],
                        "projectType" : "Runtime" ]


### PR DESCRIPTION
This is to avoid failing trying to resolve org.mule.runtime:api-annotations:jar:1.1.0-20200709
which only is available in private repos ci-releases and releases-ee