### PR TITLE
fix/DBCON-267: updates /api references path to point to mule-db-clien…

### DIFF
--- a/dsl/src/test/resources/full-artifact-config-dsl-app.json
+++ b/dsl/src/test/resources/full-artifact-config-dsl-app.json
@@ -292,7 +292,7 @@
                       "type": "NUMBER"
                     }
                   },
-                  "typeId": "org.mule.extension.db.api.config.DbPoolingProfile"
+                  "typeId": "org.mule.db.commons.api.api.config.DbPoolingProfile"
                 }
               }
             ]
@@ -532,7 +532,7 @@
                       "type": "NUMBER"
                     }
                   },
-                  "typeId": "org.mule.extension.db.api.config.DbPoolingProfile"
+                  "typeId": "org.mule.db.commons.api.api.config.DbPoolingProfile"
                 }
               }
             ]
@@ -1046,7 +1046,7 @@
                                   "type": "STRING"
                                 }
                               },
-                              "typeId": "org.mule.extension.db.api.param.ParameterType"
+                              "typeId": "org.mule.db.commons.api.api.param.ParameterType"
                             },
                             {
                               "fields": {
@@ -1061,7 +1061,7 @@
                                   "type": "STRING"
                                 }
                               },
-                              "typeId": "org.mule.extension.db.api.param.ParameterType"
+                              "typeId": "org.mule.db.commons.api.api.param.ParameterType"
                             }
                           ]
                         }
@@ -1191,7 +1191,7 @@
                           "type": "STRING"
                         }
                       },
-                      "typeId": "org.mule.extension.db.api.param.ParameterType"
+                      "typeId": "org.mule.db.commons.api.api.param.ParameterType"
                     },
                     {
                       "fields": {
@@ -1206,7 +1206,7 @@
                           "type": "STRING"
                         }
                       },
-                      "typeId": "org.mule.extension.db.api.param.ParameterType"
+                      "typeId": "org.mule.db.commons.api.api.param.ParameterType"
                     }
                   ]
                 }
@@ -1296,7 +1296,7 @@
                           "type": "STRING"
                         }
                       },
-                      "typeId": "org.mule.extension.db.api.param.ParameterType"
+                      "typeId": "org.mule.db.commons.api.api.param.ParameterType"
                     }
                   ]
                 },

--- a/dsl/src/test/resources/full-artifact-config-dsl-app.json
+++ b/dsl/src/test/resources/full-artifact-config-dsl-app.json
@@ -292,7 +292,7 @@
                       "type": "NUMBER"
                     }
                   },
-                  "typeId": "org.mule.db.commons.api.api.config.DbPoolingProfile"
+                  "typeId": "org.mule.db.commons.api.config.DbPoolingProfile"
                 }
               }
             ]
@@ -532,7 +532,7 @@
                       "type": "NUMBER"
                     }
                   },
-                  "typeId": "org.mule.db.commons.api.api.config.DbPoolingProfile"
+                  "typeId": "org.mule.db.commons.api.config.DbPoolingProfile"
                 }
               }
             ]
@@ -1046,7 +1046,7 @@
                                   "type": "STRING"
                                 }
                               },
-                              "typeId": "org.mule.db.commons.api.api.param.ParameterType"
+                              "typeId": "org.mule.db.commons.api.param.ParameterType"
                             },
                             {
                               "fields": {
@@ -1061,7 +1061,7 @@
                                   "type": "STRING"
                                 }
                               },
-                              "typeId": "org.mule.db.commons.api.api.param.ParameterType"
+                              "typeId": "org.mule.db.commons.api.param.ParameterType"
                             }
                           ]
                         }
@@ -1191,7 +1191,7 @@
                           "type": "STRING"
                         }
                       },
-                      "typeId": "org.mule.db.commons.api.api.param.ParameterType"
+                      "typeId": "org.mule.db.commons.api.param.ParameterType"
                     },
                     {
                       "fields": {
@@ -1206,7 +1206,7 @@
                           "type": "STRING"
                         }
                       },
-                      "typeId": "org.mule.db.commons.api.api.param.ParameterType"
+                      "typeId": "org.mule.db.commons.api.param.ParameterType"
                     }
                   ]
                 }
@@ -1296,7 +1296,7 @@
                           "type": "STRING"
                         }
                       },
-                      "typeId": "org.mule.db.commons.api.api.param.ParameterType"
+                      "typeId": "org.mule.db.commons.api.param.ParameterType"
                     }
                   ]
                 },


### PR DESCRIPTION
…t, because of change in mule-db-connector master/2.0.0-SNAPSHOT.

It's the same as #1443, but couldn't cherry-pick it.
