### PR TITLE
DEL-3322: Fix MuleTestArtifacts dependency entry to use 4.4.0-SNAPSHO…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
                         <exclude>org.mule.modules:mule-spring-module-tests</exclude>
                         <exclude>org.mule.modules:mule-spring-test-plugin</exclude>
                         <exclude>org.mule.tests:test-components</exclude>
+                        <exclude>org.mule.tooling:tooling-support-test-extension</exclude>
                       </excludes>
                     </requireReleaseDeps>
                     <requireReleaseVersion>


### PR DESCRIPTION
…T as the deploy of tooling-support-test-extension is skipped in mule-test-artifacts repo