### PR TITLE
MULE-17711: Remove ComponentAst that are parameters from the innerComponets collection

### DIFF
--- a/extensions-xml-support/src/test/java/org/mule/test/integration/locator/LazyInitConfigurationXmlSdk1ComponentLocatorTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/locator/LazyInitConfigurationXmlSdk1ComponentLocatorTestCase.java
@@ -54,7 +54,7 @@ public class LazyInitConfigurationXmlSdk1ComponentLocatorTestCase extends MuleAr
   public SystemProperty path = new SystemProperty("path", "path");
 
 
-  private static final int TOTAL_NUMBER_OF_LOCATIONS = 38;
+  private static final int TOTAL_NUMBER_OF_LOCATIONS = 36;
 
   @Inject
   private LazyComponentInitializer lazyComponentInitializer;
@@ -94,8 +94,6 @@ public class LazyInitConfigurationXmlSdk1ComponentLocatorTestCase extends MuleAr
                                   "github-httpreq-config-sample-config/connection/0",
                                   "github-httpreq-config-sample-config/connection/0/0",
                                   "get-channels/processors/0",
-                                  "get-channels/processors/0/0",
-                                  "get-channels/processors/0/1",
                                   "get-channels/processors/1",
 
                                   "sample-config",

--- a/integration/src/test/java/org/mule/test/config/spring/parsers/XmlDslProcessingValidationTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/spring/parsers/XmlDslProcessingValidationTestCase.java
@@ -6,39 +6,57 @@
  */
 package org.mule.test.config.spring.parsers;
 
+import static java.util.Collections.emptySet;
 import static org.junit.rules.ExpectedException.none;
+import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
 
-import org.mule.functional.junit4.ApplicationContextBuilder;
-import org.mule.tck.junit4.AbstractMuleTestCase;
-import org.mule.test.IntegrationTestCaseRunnerConfig;
+import org.mule.functional.junit4.AbstractConfigurationFailuresTestCase;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.core.api.config.ConfigurationException;
+import org.mule.tests.api.TestComponentsExtension;
 
-import org.junit.Ignore;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.qameta.allure.Story;
+
 // TODO MULE-18446 Migrate this test to a unit test where the implementation of the validation will be
-@Ignore("MULE-18446")
-public class XmlDslProcessingValidationTestCase extends AbstractMuleTestCase implements IntegrationTestCaseRunnerConfig {
+@Story(DSL_VALIDATION_STORY)
+public class XmlDslProcessingValidationTestCase extends AbstractConfigurationFailuresTestCase {
 
   @Rule
   public ExpectedException expectedException = none();
 
   @Test
-  @Ignore("MULE-17711")
   public void parameterAndChildAtOnce() throws Exception {
-    expectedException
-        .expectMessage("Component parsers-test:element-with-attribute-and-child has a child element parsers-test:my-pojo which is used for the same purpose of the configuration parameter myPojo. Only one must be used.");
-    new ApplicationContextBuilder().setApplicationResources(new String[] {
-        "org/mule/config/spring/parsers/dsl-validation-duplicate-pojo-or-list-parameter-config.xml"}).build();
+    String configFile = "org/mule/config/spring/parsers/dsl-validation-duplicate-pojo-or-list-parameter-config.xml";
+    expectedException.expectMessage("[" + configFile + ":9]: "
+        + "Component 'test-components:element-with-attribute-and-child' has a child element 'test-components:my-pojo'"
+        + " which is used for the same purpose of the configuration parameter 'myPojo'. Only one must be used.");
+    loadConfiguration(configFile);
   }
 
   @Test
   public void emptyChildSimpleParameter() throws Exception {
+    String configFile = "org/mule/config/spring/parsers/dsl-validation-empty-simple-child-parameter.xml";
+
+    expectedException.expect(ConfigurationException.class);
     expectedException
-        .expectMessage("Parameter at org/mule/config/spring/parsers/dsl-validation-empty-simple-child-parameter.xml:10 must provide a non-empty value");
-    new ApplicationContextBuilder().setApplicationResources(new String[] {
-        "org/mule/config/spring/parsers/dsl-validation-empty-simple-child-parameter.xml"}).build();
+        .expectMessage("[" + configFile + ":9]: Element <test-components:text-pojo> is missing required parameter 'text'.");
+    loadConfiguration(configFile);
   }
 
+  @Override
+  protected List<ExtensionModel> getRequiredExtensions() {
+    ExtensionModel testComponents = loadExtension(TestComponentsExtension.class, emptySet());
+
+    final List<ExtensionModel> extensions = new ArrayList<>();
+    extensions.add(testComponents);
+
+    return extensions;
+  }
 }

--- a/integration/src/test/java/org/mule/test/integration/locator/LazyInitConfigurationComponentLocatorTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/locator/LazyInitConfigurationComponentLocatorTestCase.java
@@ -61,7 +61,7 @@ public class LazyInitConfigurationComponentLocatorTestCase extends AbstractInteg
   public SystemProperty path = new SystemProperty("path", "path");
 
 
-  private static final int TOTAL_NUMBER_OF_LOCATIONS = 97;
+  private static final int TOTAL_NUMBER_OF_LOCATIONS = 96;
   @Inject
   private Registry registry;
 
@@ -131,7 +131,6 @@ public class LazyInitConfigurationComponentLocatorTestCase extends AbstractInteg
                                   "flowLvl1/processors/0",
                                   "flowLvl2",
                                   "flowLvl2/processors/0",
-                                  "flowLvl2/processors/0/0",
                                   "flowLvl2/processors/1",
                                   "flowRecursive",
                                   "flowRecursive/processors/0",

--- a/integration/src/test/resources/org/mule/config/spring/parsers/dsl-validation-duplicate-pojo-or-list-parameter-config.xml
+++ b/integration/src/test/resources/org/mule/config/spring/parsers/dsl-validation-duplicate-pojo-or-list-parameter-config.xml
@@ -7,9 +7,7 @@
        http://www.mulesoft.org/schema/mule/test-components http://www.mulesoft.org/schema/mule/test-components/current/mule-test-components.xsd">
 
     <test-components:element-with-attribute-and-child name="pojoWithChild" myPojo="jose">
-        <test-components:my-pojo>
-            <test-components:my-pojo someParameter="pepe"/>
-        </test-components:my-pojo>
+        <test-components:my-pojo someParameter="pepe"/>
     </test-components:element-with-attribute-and-child>
 
 </mule>

--- a/oauth/src/test/java/org/mule/test/module/extension/oauth/authcode/LazyInitConfigurationComponentLocatorTestCase.java
+++ b/oauth/src/test/java/org/mule/test/module/extension/oauth/authcode/LazyInitConfigurationComponentLocatorTestCase.java
@@ -72,8 +72,6 @@ public class LazyInitConfigurationComponentLocatorTestCase extends BaseOAuthExte
 
                                   "oauth",
                                   "oauth/connection",
-                                  "oauth/connection/0",
-                                  "oauth/connection/1",
 
                                   "getConnection",
                                   "getConnection/processors/0",
@@ -108,7 +106,6 @@ public class LazyInitConfigurationComponentLocatorTestCase extends BaseOAuthExte
 
                                   "entitiesMetadata",
                                   "entitiesMetadata/processors/0",
-                                  "entitiesMetadata/processors/0/0",
 
                                   "values",
                                   "values/processors/0",

--- a/security/src/test/java/org/mule/test/integration/locator/LazyInitSecurityConfigurationComponentLocatorTestCase.java
+++ b/security/src/test/java/org/mule/test/integration/locator/LazyInitSecurityConfigurationComponentLocatorTestCase.java
@@ -43,7 +43,7 @@ import io.qameta.allure.Story;
 
 @Feature(CONFIGURATION_COMPONENT_LOCATOR)
 @Story(SEARCH_CONFIGURATION)
-public class LazyInitConfigurationComponentLocatorTestCase extends MuleArtifactFunctionalTestCase
+public class LazyInitSecurityConfigurationComponentLocatorTestCase extends MuleArtifactFunctionalTestCase
     implements IntegrationTestCaseRunnerConfig {
 
   @Rule
@@ -93,7 +93,6 @@ public class LazyInitConfigurationComponentLocatorTestCase extends MuleArtifactF
                                   "SecureUMO2",
                                   "SecureUMO2/source",
                                   "SecureUMO2/processors/0",
-                                  "SecureUMO2/processors/0/0",
                                   "SecureUMO2/processors/0/0/0",
                                   "SecureUMO2/processors/1"));
   }

--- a/security/src/test/java/org/mule/test/integration/security/CustomSecurityFilterTestCase.java
+++ b/security/src/test/java/org/mule/test/integration/security/CustomSecurityFilterTestCase.java
@@ -40,10 +40,8 @@ public class CustomSecurityFilterTestCase extends MuleArtifactFunctionalTestCase
   private static final String EXPECTED_PASSWORD = "ross";
 
   @Override
-  protected String[] getConfigFiles() {
-    return new String[] {
-        "org/mule/test/integration/security/custom-security-filter-test.xml"
-    };
+  protected String getConfigFile() {
+    return "org/mule/test/integration/security/custom-security-filter-test.xml";
   }
 
   @Test


### PR DESCRIPTION
* Params represented as child elements do not have a location, only components have locations