### PR TITLE
MULE-19774: test GrizzlyHttpClient selector pool initialization (#1602)

### DIFF
--- a/integration/src/test/java/org/mule/test/http/GrizzlyHttpClientSchedulerTestCase.java
+++ b/integration/src/test/java/org/mule/test/http/GrizzlyHttpClientSchedulerTestCase.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.http;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mule.runtime.api.scheduler.SchedulerConfig.config;
+import static org.mule.tck.junit4.matcher.Eventually.eventually;
+import io.qameta.allure.Description;
+import io.qameta.allure.Issue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.runtime.api.scheduler.Scheduler;
+import org.mule.runtime.api.scheduler.SchedulerConfig;
+import org.mule.runtime.api.scheduler.SchedulerPoolsConfigFactory;
+import org.mule.runtime.api.scheduler.SchedulerService;
+import org.mule.runtime.api.scheduler.SchedulerView;
+import org.mule.runtime.api.util.concurrent.Latch;
+import org.mule.runtime.http.api.HttpService;
+import org.mule.runtime.http.api.client.HttpClient;
+import org.mule.runtime.http.api.client.HttpClientConfiguration;
+import org.mule.test.AbstractIntegrationTestCase;
+
+import javax.inject.Inject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Issue("MULE-19774")
+public class GrizzlyHttpClientSchedulerTestCase extends AbstractIntegrationTestCase {
+
+  // We need an empty app in order to run an integration test to get the scheduler Service and http Service
+  @Override
+  protected String getConfigFile() {
+    return "org/mule/test/integration/http/dummy-app.xml";
+  }
+
+  @Inject
+  private HttpService httpService;
+
+  @Inject
+  private SchedulerService schedulerService;
+
+  private Latch lockLatch;
+  private Latch startTestLatch;
+  private AtomicReference<Scheduler> schedulerReference;
+  private HttpClient httpClient;
+  private TestSchedulerService testSchedulerService;
+
+  @Before
+  public void initialize() throws Exception {
+    lockLatch = new Latch();
+    startTestLatch = new Latch();
+    schedulerReference = new AtomicReference<>();
+    httpClient =
+        httpService.getClientFactory().create(new HttpClientConfiguration.Builder().setName("http-client-scheduler").build());
+    testSchedulerService = new TestSchedulerService(schedulerService) {
+
+      @Override
+      public Scheduler customScheduler(SchedulerConfig config, int queueSize) {
+        Scheduler scheduler = schedulerServiceDelegate.customScheduler(config, queueSize);
+        schedulerReference.set(scheduler);
+        scheduler.execute(() -> {
+          try {
+            startTestLatch.release();
+            lockLatch.await();
+          } catch (InterruptedException e) {
+            fail("Fail initializing selector pool");
+          }
+        });
+        try {
+          startTestLatch.await();
+        } catch (InterruptedException e) {
+          fail(e.getMessage());
+        }
+        return scheduler;
+      }
+    };
+
+    Field schedulerServiceField = httpClient.getClass().getDeclaredField("schedulerService");
+    setFinalField(httpClient, schedulerServiceField, testSchedulerService);
+  }
+
+  @Test
+  @Description("Start the pool with an scheduler running a blocked task. The selector pool should success to start sending one task to the queue.")
+  public void testSchedulerWithNonFinishTask() throws NoSuchFieldException, IllegalAccessException {
+    // We need to run in a scheduler thread to ensure it fail with a rejectedExecution if the queue size is 0
+    Future future = schedulerService.customScheduler(config()
+        .withDirectRunCpuLightWhenTargetBusy(true)
+        .withMaxConcurrentTasks(1)
+        .withName("TEST")).submit(() -> {
+          httpClient.start();
+          lockLatch.release();
+        });
+    try {
+      future.get(5, SECONDS);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) getPrivateField(schedulerReference.get(), "executor");
+    assertThat(executor.getQueue(), is(eventually(empty())));
+  }
+
+  private static class TestSchedulerService implements SchedulerService {
+
+    protected SchedulerService schedulerServiceDelegate;
+
+    private TestSchedulerService(SchedulerService schedulerServiceDelegate) {
+      this.schedulerServiceDelegate = schedulerServiceDelegate;
+    }
+
+    @Override
+    public String getName() {
+      return schedulerServiceDelegate.getName();
+    }
+
+    @Override
+    public Scheduler cpuLightScheduler() {
+      return schedulerServiceDelegate.cpuLightScheduler();
+    }
+
+    @Override
+    public Scheduler ioScheduler() {
+      return schedulerServiceDelegate.ioScheduler();
+    }
+
+    @Override
+    public Scheduler cpuIntensiveScheduler() {
+      return schedulerServiceDelegate.cpuIntensiveScheduler();
+    }
+
+    @Override
+    public Scheduler cpuLightScheduler(SchedulerConfig config) {
+      return schedulerServiceDelegate.cpuLightScheduler(config);
+    }
+
+    @Override
+    public Scheduler ioScheduler(SchedulerConfig config) {
+      return schedulerServiceDelegate.ioScheduler(config);
+    }
+
+    @Override
+    public Scheduler cpuIntensiveScheduler(SchedulerConfig config) {
+      return schedulerServiceDelegate.cpuIntensiveScheduler(config);
+    }
+
+    @Override
+    public Scheduler cpuLightScheduler(SchedulerConfig config, SchedulerPoolsConfigFactory poolsConfigFactory) {
+      return schedulerServiceDelegate.cpuLightScheduler(config, poolsConfigFactory);
+    }
+
+    @Override
+    public Scheduler ioScheduler(SchedulerConfig config, SchedulerPoolsConfigFactory poolsConfigFactory) {
+      return schedulerServiceDelegate.ioScheduler(config, poolsConfigFactory);
+    }
+
+    @Override
+    public Scheduler cpuIntensiveScheduler(SchedulerConfig config, SchedulerPoolsConfigFactory poolsConfigFactory) {
+      return schedulerServiceDelegate.cpuIntensiveScheduler(config, poolsConfigFactory);
+    }
+
+    @Override
+    public Scheduler customScheduler(SchedulerConfig config) {
+      return schedulerServiceDelegate.customScheduler(config);
+    }
+
+    @Override
+    public Scheduler customScheduler(SchedulerConfig config, int queueSize) {
+      return schedulerServiceDelegate.customScheduler(config, queueSize);
+    }
+
+    @Override
+    public List<SchedulerView> getSchedulers() {
+      return schedulerServiceDelegate.getSchedulers();
+    }
+  }
+
+  private void setFinalField(Object object, Field field, Object newValue) throws Exception {
+    field.setAccessible(true);
+
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+    field.set(object, newValue);
+  }
+
+  private Object getPrivateField(Object obj, String field) throws NoSuchFieldException, IllegalAccessException {
+    Field f = obj.getClass().getDeclaredField(field);
+    f.setAccessible(true);
+    return f.get(obj);
+  }
+}

--- a/integration/src/test/resources/org/mule/test/integration/http/dummy-app.xml
+++ b/integration/src/test/resources/org/mule/test/integration/http/dummy-app.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+</mule>


### PR DESCRIPTION
* MULE-19774: test GrizzlyHttpClient selector pool initialization

(cherry picked from commit 88523762b466ea3e2e2b0154ccfd16ade96483b2)