### PR TITLE
MULE-19916: Redelivery Policy: failure to obtain message ID from expression causes source to stop listening for messages when it uses transactions (#1612)

### DIFF
--- a/integration/src/test/java/org/mule/test/components/RedeliveryPolicyTestCase.java
+++ b/integration/src/test/java/org/mule/test/components/RedeliveryPolicyTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.test.components;
 
 import static java.lang.Runtime.getRuntime;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.is;
@@ -18,16 +19,29 @@ import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JAVA;
 import static org.mule.tck.probe.PollingProber.probe;
 
 import org.mule.functional.api.component.EventCallback;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.mule.runtime.http.api.HttpConstants.Method.POST;
+
+import io.qameta.allure.Description;
+import org.junit.Rule;
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.http.api.HttpService;
+import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.runtime.http.api.domain.message.response.HttpResponse;
+import org.mule.service.http.TestHttpClient;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 import org.mule.test.runner.RunnerDelegateTo;
 import org.mule.tests.api.TestQueueManager;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.inject.Inject;
@@ -44,6 +58,12 @@ public class RedeliveryPolicyTestCase extends AbstractIntegrationTestCase {
 
   private static CountDownLatch latch;
   private static AtomicInteger awaiting = new AtomicInteger();
+
+  @Rule
+  public DynamicPort port = new DynamicPort("port");
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
 
   public static class LatchAwaitCallback extends AbstractComponent implements EventCallback {
 
@@ -140,6 +160,46 @@ public class RedeliveryPolicyTestCase extends AbstractIntegrationTestCase {
                queueManager.read("errorHandlerMessageQueue", RECEIVE_TIMEOUT, MILLISECONDS), notNullValue());
     assertThat("Error handler was called more than once",
                queueManager.read("errorHandlerMessageQueue", RECEIVE_TIMEOUT, MILLISECONDS), nullValue());
+  }
+
+  @Test
+  @Issue("MULE-19916")
+  @Description("Test that when the evaluation of the message ID expression for the redelivery policy fails " +
+      "for a message from a source configured with transactions, the transaction is not rollbacked by the source " +
+      "because of the flow finishing with an error.")
+  public void redeliveryInvalidMessageIdWithTransactionalSourceAndCustomErrorHandler() throws Exception {
+    flowRunner("redeliveryInvalidMessageIdWithTransactionalSourceAndCustomErrorHandlerDispatch").runExpectingException();
+    assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce("transactionalSourceCustomErrorHandlerMessageQueue");
+  }
+
+  @Test
+  @Issue("MULE-19916")
+  @Description("Test that when the evaluation of the message ID expression for the redelivery policy fails " +
+      "for a message from a source configured with transactions, the transaction is not rollbacked by the error handler.")
+  public void redeliveryInvalidMessageIdWithTransactionalSourceAndDefaultErrorHandler() throws Exception {
+    flowRunner("redeliveryInvalidMessageIdWithTransactionalSourceAndDefaultErrorHandlerDispatch").runExpectingException();
+    assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
+  }
+
+  @Test
+  @Issue("MULE-19916")
+  @Description("Test that when the evaluation of the message ID expression for the redelivery policy fails, " +
+      "the flow finishes and a response is sent.")
+  public void redeliveryInvalidMessageIdWithHttpListener() throws Exception {
+    assertThat(sendThroughHttp("invalidMessageId").getStatusCode(), is(INTERNAL_SERVER_ERROR.getStatusCode()));
+    assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
+  }
+
+  private void assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce(String queueName) {
+    assertThat("Message ID was not invalid", queueManager.read(queueName, RECEIVE_TIMEOUT, MILLISECONDS), notNullValue());
+    assertThat("Invalid message ID error thrown more than once", queueManager.read(queueName, RECEIVE_TIMEOUT, MILLISECONDS),
+               nullValue());
+  }
+
+  private HttpResponse sendThroughHttp(String path) throws IOException, TimeoutException {
+    HttpRequest request = HttpRequest.builder().uri(format("http://localhost:%s/%s", port.getNumber(), path)).method(POST)
+        .entity(new ByteArrayHttpEntity(TEST_MESSAGE.getBytes())).build();
+    return httpClient.send(request, RECEIVE_TIMEOUT, false, null);
   }
 
   private static class PojoPayload {

--- a/integration/src/test/resources/org/mule/test/components/redelivery-policy-config.xml
+++ b/integration/src/test/resources/org/mule/test/components/redelivery-policy-config.xml
@@ -4,10 +4,21 @@
       xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
       xmlns:test="http://www.mulesoft.org/schema/mule/test"
       xmlns:test-components="http://www.mulesoft.org/schema/mule/test-components"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
                            http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
                            http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-                           http://www.mulesoft.org/schema/mule/test-components http://www.mulesoft.org/schema/mule/test-components/current/mule-test-components.xsd">
+                           http://www.mulesoft.org/schema/mule/test-components http://www.mulesoft.org/schema/mule/test-components/current/mule-test-components.xsd
+                           http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <configuration defaultErrorHandler-ref="globalErrorHandler" />
+
+    <error-handler name="globalErrorHandler">
+        <on-error-propagate type="EXPRESSION">
+            <set-payload value="#[error]"/>
+            <test-components:queue-push config-ref="expressionErrorDefaultErrorHandlerMessageQueue"/>
+        </on-error-propagate>
+    </error-handler>
 
     <vm:config name="VM_Config">
         <vm:queues >
@@ -15,6 +26,8 @@
           <vm:queue queueName="Q2" />
           <vm:queue queueName="Q3" />
           <vm:queue queueName="Q4" />
+          <vm:queue queueName="Q5" />
+          <vm:queue queueName="Q6" />
         </vm:queues>
     </vm:config>
 
@@ -29,6 +42,18 @@
     <test-components:queue-config name="errorHandlerMessageQueue">
         <test-components:connection />
     </test-components:queue-config>
+
+    <test-components:queue-config name="transactionalSourceCustomErrorHandlerMessageQueue">
+        <test-components:connection />
+    </test-components:queue-config>
+
+    <test-components:queue-config name="expressionErrorDefaultErrorHandlerMessageQueue">
+        <test-components:connection />
+    </test-components:queue-config>
+
+    <http:listener-config name="listenerConfig">
+        <http:listener-connection host="localhost" port="${port}"/>
+    </http:listener-config>
 
     <flow name="redeliveryPolicyFlowDispatch">
         <vm:publish-consume queueName="Q1" config-ref="VM_Config" timeout="1"/>
@@ -59,7 +84,7 @@
         <test:processor processingType="BLOCKING">
             <test:callback class="org.mule.test.components.RedeliveryPolicyTestCase$LatchAwaitCallback"/>
         </test:processor>
-        
+
         <error-handler>
             <on-error-propagate type="MULE:REDELIVERY_EXHAUSTED">
                 <test-components:queue-push config-ref="redeliveredMessageQueue"/>
@@ -94,5 +119,44 @@
                 <test-components:queue-push config-ref="errorHandlerMessageQueue"/>
             </on-error-propagate>
         </error-handler>
+    </flow>
+
+    <flow name="redeliveryInvalidMessageIdWithTransactionalSourceAndCustomErrorHandlerDispatch">
+        <vm:publish-consume queueName="Q5" config-ref="VM_Config"/>
+    </flow>
+
+    <flow name="redeliveryInvalidMessageIdWithTransactionalSourceAndCustomErrorHandlerProcess">
+        <vm:listener queueName="Q5" config-ref="VM_Config" transactionalAction="ALWAYS_BEGIN">
+            <redelivery-policy idExpression="!null.a"/>
+        </vm:listener>
+
+        <logger/>
+
+        <error-handler>
+            <on-error-propagate type="EXPRESSION">
+                <set-payload value="#[error]"/>
+                <test-components:queue-push config-ref="transactionalSourceCustomErrorHandlerMessageQueue"/>
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+
+    <flow name="redeliveryInvalidMessageIdWithTransactionalSourceAndDefaultErrorHandlerDispatch">
+        <vm:publish-consume queueName="Q6" config-ref="VM_Config"/>
+    </flow>
+
+    <flow name="redeliveryInvalidMessageIdWithTransactionalSourceAndDefaultErrorHandlerProcess">
+        <vm:listener queueName="Q6" config-ref="VM_Config" transactionalAction="ALWAYS_BEGIN">
+            <redelivery-policy idExpression="!null.a"/>
+        </vm:listener>
+
+        <logger/>
+    </flow>
+
+    <flow name="redeliveryInvalidMessageIdWithHttpListener">
+        <http:listener path="invalidMessageId" config-ref="listenerConfig">
+            <redelivery-policy idExpression="!null.a"/>
+        </http:listener>
+
+        <logger/>
     </flow>
 </mule>


### PR DESCRIPTION
(cherry picked from commit 18c8b8a5322e0c0923c0fbbed9f4ec7299bf68bd)