### PR TITLE
MULE-19921: Redelivery Policy: infinite loop with blank message ID in a source configured with transactions (#1619)

### DIFF
--- a/integration/src/test/java/org/mule/test/components/RedeliveryPolicyTestCase.java
+++ b/integration/src/test/java/org/mule/test/components/RedeliveryPolicyTestCase.java
@@ -166,20 +166,20 @@ public class RedeliveryPolicyTestCase extends AbstractIntegrationTestCase {
   @Test
   @Issue("MULE-19916")
   @Description("Test that when the evaluation of the message ID expression for the redelivery policy fails " +
-      "for a message from a source configured with transactions, the transaction is not rollbacked by the source " +
+      "for a message from a source configured with transactions, the transaction is not rolled back by the source " +
       "because of the flow finishing with an error.")
   public void redeliveryInvalidMessageIdWithTransactionalSourceAndCustomErrorHandler() throws Exception {
     flowRunner("redeliveryInvalidMessageIdWithTransactionalSourceAndCustomErrorHandlerDispatch").runExpectingException();
-    assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce("transactionalSourceCustomErrorHandlerMessageQueue");
+    assertExpressionErrorRaisedOnlyOnce("transactionalSourceCustomErrorHandlerMessageQueue");
   }
 
   @Test
   @Issue("MULE-19916")
   @Description("Test that when the evaluation of the message ID expression for the redelivery policy fails " +
-      "for a message from a source configured with transactions, the transaction is not rollbacked by the error handler.")
+      "for a message from a source configured with transactions, the transaction is not rolled back by the error handler.")
   public void redeliveryInvalidMessageIdWithTransactionalSourceAndDefaultErrorHandler() throws Exception {
     flowRunner("redeliveryInvalidMessageIdWithTransactionalSourceAndDefaultErrorHandlerDispatch").runExpectingException();
-    assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
+    assertExpressionErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
   }
 
   @Test
@@ -188,10 +188,29 @@ public class RedeliveryPolicyTestCase extends AbstractIntegrationTestCase {
       "the flow finishes and a response is sent.")
   public void redeliveryInvalidMessageIdWithHttpListener() throws Exception {
     assertThat(sendThroughHttp("invalidMessageId").getStatusCode(), is(INTERNAL_SERVER_ERROR.getStatusCode()));
-    assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
+    assertExpressionErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
   }
 
-  private void assertRedeliveryInvalidMessageIdErrorRaisedOnlyOnce(String queueName) {
+  @Test
+  @Issue("MULE-19921")
+  @Description("Test that when the message ID of the redelivery policy is blank for a message from a source " +
+      "configured with transactions, the transaction is not rolled back by the source " +
+      "because of the flow finishing with an error.")
+  public void redeliveryBlankMessageIdWithTransactionalSourceAndCustomErrorHandler() throws Exception {
+    flowRunner("redeliveryBlankMessageIdWithTransactionalSourceAndCustomErrorHandlerDispatch").runExpectingException();
+    assertExpressionErrorRaisedOnlyOnce("transactionalSourceCustomErrorHandlerMessageQueue");
+  }
+
+  @Test
+  @Issue("MULE-19921")
+  @Description("Test that when the message ID of the redelivery policy is blank for a message from a source " +
+      "configured with transactions, the transaction is not rolled back by the error handler.")
+  public void redeliveryBlankMessageIdWithTransactionalSourceAndDefaultErrorHandler() throws Exception {
+    flowRunner("redeliveryBlankMessageIdWithTransactionalSourceAndDefaultErrorHandlerDispatch").runExpectingException();
+    assertExpressionErrorRaisedOnlyOnce("expressionErrorDefaultErrorHandlerMessageQueue");
+  }
+
+  private void assertExpressionErrorRaisedOnlyOnce(String queueName) {
     assertThat("Message ID was not invalid", queueHandler.read(queueName, RECEIVE_TIMEOUT), notNullValue());
     assertThat("Invalid message ID error thrown more than once", queueHandler.read(queueName, RECEIVE_TIMEOUT),
                nullValue());

--- a/integration/src/test/resources/org/mule/test/components/redelivery-policy-config.xml
+++ b/integration/src/test/resources/org/mule/test/components/redelivery-policy-config.xml
@@ -26,6 +26,8 @@
           <vm:queue queueName="Q4" />
           <vm:queue queueName="Q5" />
           <vm:queue queueName="Q6" />
+          <vm:queue queueName="Q7" />
+          <vm:queue queueName="Q8" />
         </vm:queues>
     </vm:config>
 
@@ -134,6 +136,37 @@
         <http:listener path="invalidMessageId" config-ref="listenerConfig">
             <redelivery-policy idExpression="!null.a"/>
         </http:listener>
+
+        <logger/>
+    </flow>
+
+    <flow name="redeliveryBlankMessageIdWithTransactionalSourceAndCustomErrorHandlerDispatch">
+        <vm:publish-consume queueName="Q7" config-ref="VM_Config"/>
+    </flow>
+
+    <flow name="redeliveryBlankMessageIdWithTransactionalSourceAndCustomErrorHandlerProcess">
+        <vm:listener queueName="Q7" config-ref="VM_Config" transactionalAction="ALWAYS_BEGIN">
+            <redelivery-policy idExpression="payload.id"/>
+        </vm:listener>
+
+        <logger/>
+
+        <error-handler>
+            <on-error-propagate type="EXPRESSION">
+                <set-payload value="#[error]"/>
+                <test:queue name="transactionalSourceCustomErrorHandlerMessageQueue"/>
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+
+    <flow name="redeliveryBlankMessageIdWithTransactionalSourceAndDefaultErrorHandlerDispatch">
+        <vm:publish-consume queueName="Q8" config-ref="VM_Config"/>
+    </flow>
+
+    <flow name="redeliveryBlankMessageIdWithTransactionalSourceAndDefaultErrorHandlerProcess">
+        <vm:listener queueName="Q8" config-ref="VM_Config" transactionalAction="ALWAYS_BEGIN">
+            <redelivery-policy idExpression="payload.id"/>
+        </vm:listener>
 
         <logger/>
     </flow>


### PR DESCRIPTION
(cherry picked from commit 7e552e7e49407d77768043eaf9a205e185032848)