### PR TITLE
MULE-19900: test parse template with nested backslash (#1621)

### DIFF
--- a/integration/src/test/java/org/mule/test/processors/ParseTemplateTestCase.java
+++ b/integration/src/test/java/org/mule/test/processors/ParseTemplateTestCase.java
@@ -19,6 +19,7 @@ import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.test.allure.AllureConstants.ComponentsFeature.CORE_COMPONENTS;
 import static org.mule.test.allure.AllureConstants.ComponentsFeature.ParseTemplateStory.PARSE_TEMPLATE;
 
+import io.qameta.allure.Issue;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.test.AbstractIntegrationTestCase;
@@ -240,4 +241,10 @@ public class ParseTemplateTestCase extends AbstractIntegrationTestCase {
     assertEquals(PARSED_NO_EXPRESSION, msg);
   }
 
+  @Test
+  @Issue("MULE-19900")
+  public void nestedBackslash() throws Exception {
+    CoreEvent event = flowRunner("nestedBackslash").withVariable("method", "GET").run();
+    assertThat(event.getMessage().getPayload().getValue(), equalTo("get:\\test\\GET"));
+  }
 }

--- a/integration/src/test/resources/org/mule/processors/parse-template-config.xml
+++ b/integration/src/test/resources/org/mule/processors/parse-template-config.xml
@@ -148,4 +148,9 @@
         <parse-template location="org/mule/processors/no-expression.ptem" target="someVar" targetValue="#[payload]"/>
     </flow>
 
+    <flow name="nestedBackslash" initialState="stopped">
+        <parse-template>
+            <content>#["get:\\test\\" ++ vars.method]</content>
+        </parse-template>
+    </flow>
 </mule>


### PR DESCRIPTION
* MULE-19900: test parse template with nested backslash

(cherry picked from commit c4a30d880a9a6866875b84b8901a1e7384878eda)