### PR TITLE
MULE-19918: Add maven profile that skip tests on projects we don't want to test with hawk. (#1615)

### DIFF
--- a/tooling-support-tests/pom.xml
+++ b/tooling-support-tests/pom.xml
@@ -115,4 +115,22 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>no-large-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.2</version>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
(cherry picked from commit 2f0f06b6999960de0d702d9cfb47e0f214aed96c)