### PR TITLE
MULE-20012: Custom object serializer mishandled when lazy init is run multiple times (#1648)

### DIFF
--- a/integration/src/test/java/org/mule/test/config/spring/CustomObjectSerializerLazyInitTestCase.java
+++ b/integration/src/test/java/org/mule/test/config/spring/CustomObjectSerializerLazyInitTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.config.spring;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.junit.Test;
+import org.mule.runtime.api.component.location.Location;
+import org.mule.runtime.api.serialization.ObjectSerializer;
+import org.mule.runtime.api.serialization.SerializationProtocol;
+import org.mule.runtime.config.api.LazyComponentInitializer;
+import org.mule.test.AbstractIntegrationTestCase;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mule.runtime.api.component.location.Location.builder;
+import static org.mule.runtime.config.api.LazyComponentInitializer.LAZY_COMPONENT_INITIALIZER_SERVICE_KEY;
+import static org.mule.test.allure.AllureConstants.LazyInitializationFeature.LAZY_INITIALIZATION;
+import static org.mule.test.allure.AllureConstants.ObjectSerializer.CUSTOM_OBJECT_SERIALIZER;
+
+@Feature(LAZY_INITIALIZATION)
+@Story(CUSTOM_OBJECT_SERIALIZER)
+public class CustomObjectSerializerLazyInitTestCase extends AbstractIntegrationTestCase {
+
+  private static final String FIRST_LOCATION = "flow1";
+  private static final String SECOND_LOCATION = "flow2";
+
+  @Inject
+  @Named(value = LAZY_COMPONENT_INITIALIZER_SERVICE_KEY)
+  private LazyComponentInitializer lazyComponentInitializer;
+
+  @Override
+  protected String getConfigFile() {
+    return "custom-object-serializer-lazy-init.xml";
+  }
+
+  @Override
+  public boolean enableLazyInit() {
+    return true;
+  }
+
+  @Test
+  @Issue("MULE-20012")
+  @Description("Tests that the default object serializer gets correctly overridden whenever lazy initialization is run " +
+      "more than once")
+  public void lazyInitPerformedTwice() {
+    Location location = builder().globalName(FIRST_LOCATION).build();
+    lazyComponentInitializer.initializeComponent(location);
+    assertThat(muleContext.getObjectSerializer(), instanceOf(TestSerializationProtocol.class));
+
+    /* initialize another component so beans get regenerated */
+    location = builder().globalName(SECOND_LOCATION).build();
+    lazyComponentInitializer.initializeComponent(location);
+    assertThat(muleContext.getObjectSerializer(), instanceOf(TestSerializationProtocol.class));
+  }
+
+  public static class TestSerializationProtocol implements ObjectSerializer {
+
+    @Override
+    public SerializationProtocol getInternalProtocol() {
+      return null;
+    }
+
+    @Override
+    public SerializationProtocol getExternalProtocol() {
+      return null;
+    }
+  }
+}

--- a/integration/src/test/resources/custom-object-serializer-lazy-init.xml
+++ b/integration/src/test/resources/custom-object-serializer-lazy-init.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <object name="customObjectSerializer"
+                     class="org.mule.test.config.spring.CustomObjectSerializerLazyInitTestCase.TestSerializationProtocol"/>
+
+    <configuration defaultObjectSerializer-ref="customObjectSerializer"/>
+
+    <flow name="flow1">
+        <logger />
+    </flow>
+
+    <flow name="flow2">
+        <logger />
+    </flow>
+</mule>


### PR DESCRIPTION
(cherry picked from commit 7e79d6ded5c7eabcbc31ee292d62ca6786be4059)