### PR TITLE
MULE-20019: In-memory OAuth Authorization Code Grant type credentials are overwritten (#1654)

### DIFF
--- a/oauth/src/test/java/org/mule/test/module/extension/oauth/BaseOAuthExtensionTestCase.java
+++ b/oauth/src/test/java/org/mule/test/module/extension/oauth/BaseOAuthExtensionTestCase.java
@@ -149,7 +149,15 @@ public abstract class BaseOAuthExtensionTestCase extends AbstractExtensionFuncti
     simulateCallback(callbackPort.getNumber());
   }
 
+  protected void simulateCallback(String ownerId, String accessToken) {
+    simulateCallback(callbackPort.getNumber(), ownerId, accessTokenContent(accessToken));
+  }
+
   protected void simulateCallback(int port) {
+    simulateCallback(port, ownerId, accessTokenContent());
+  }
+
+  protected void simulateCallback(int port, String ownerId, String accessTokenContent) {
     final String authCode = "chu chu ua, chu chu ua";
 
     ImmutableMap.Builder<String, String> queryParamsBuilder = ImmutableMap.builder();
@@ -161,7 +169,7 @@ public abstract class BaseOAuthExtensionTestCase extends AbstractExtensionFuncti
         .put(CODE_PARAMETER, authCode)
         .build();
 
-    stubTokenUrl(accessTokenContent());
+    stubTokenUrl(accessTokenContent);
 
     check(REQUEST_TIMEOUT, 500, () -> {
       Response response = Get(toUrl(CALLBACK_PATH, port) + "?" + encodeQueryString(queryParams)).addHeader("Connection", "close")
@@ -227,6 +235,10 @@ public abstract class BaseOAuthExtensionTestCase extends AbstractExtensionFuncti
     assertThat(connection.isImmediate(), is(true));
     assertThat(connection.getInstanceId(), is(INSTANCE_ID));
     assertThat(connection.getUserId(), is(USER_ID));
+  }
+
+  protected void stubRefreshToken(String refreshedToken) {
+    stubTokenUrl(accessTokenContent(refreshedToken));
   }
 
   protected String getCustomOwnerId() {

--- a/oauth/src/test/java/org/mule/test/module/extension/oauth/authcode/MultipleOwnersTestCase.java
+++ b/oauth/src/test/java/org/mule/test/module/extension/oauth/authcode/MultipleOwnersTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.module.extension.oauth.authcode;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.qameta.allure.Description;
+import io.qameta.allure.Issue;
+import org.junit.Test;
+import org.mule.test.module.extension.oauth.BaseOAuthExtensionTestCase;
+import org.mule.test.oauth.TestOAuthConnection;
+import org.mule.test.oauth.TestOAuthConnectionState;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class MultipleOwnersTestCase extends BaseOAuthExtensionTestCase {
+
+  @Override
+  protected String[] getConfigFiles() {
+    return new String[] {"auth-code-oauth-extension-config.xml", "oauth-extension-flows.xml"};
+  }
+
+  @Test
+  @Issue("MULE-20019")
+  @Description("Tests that only the credentials of the corresponding resource owner are updated during " +
+      "authorization, token refresh and token invalidation")
+  public void multipleResourceOwners() throws Exception {
+    ResourceOwnerData firstOwner = new ResourceOwnerData("firstOwnerId", "Xt1muTTSTkb6jRADop6QccB08SCIR3js");
+    ResourceOwnerData secondOwner = new ResourceOwnerData("secondOwnerId", "Ilvx1MdOls66E3ZxO6jHcgrYKRnX5Kyb");
+
+    simulateCallback(firstOwner.id, firstOwner.accessToken);
+    TestOAuthConnectionState firstOwnerConnection = getConnection(firstOwner.id);
+    assertThat(firstOwnerConnection.getState().getAccessToken(), is(firstOwner.accessToken));
+
+    // tests authorization
+    simulateCallback(secondOwner.id, secondOwner.accessToken);
+    TestOAuthConnectionState secondOwnerConnection = getConnection(secondOwner.id);
+    assertThat(firstOwnerConnection.getState().getAccessToken(), is(firstOwner.accessToken));
+    assertThat(secondOwnerConnection.getState().getAccessToken(), is(secondOwner.accessToken));
+
+    // tests token refresh
+    WireMock.reset();
+    stubRefreshToken(firstOwner.refreshToken);
+    flowRunner("refreshToken").withVariable(OWNER_ID_VARIABLE_NAME, firstOwner.id).run();
+    wireMock.verify(postRequestedFor(urlPathEqualTo("/" + TOKEN_PATH)));
+    assertThat(firstOwnerConnection.getState().getAccessToken(), is(firstOwner.refreshToken));
+    assertThat(secondOwnerConnection.getState().getAccessToken(), is(secondOwner.accessToken));
+
+    // tests token invalidation
+    flowRunner("unauthorize").withVariable(OWNER_ID_VARIABLE_NAME, firstOwner.id).run();
+    try {
+      firstOwnerConnection.getState().getAccessToken();
+      fail("Expected access token to be invalidated");
+    } catch (Exception e) {
+      assertThat(e.getClass().getName(), containsString("TokenInvalidatedException"));
+    }
+
+    assertThat(secondOwnerConnection.getState().getAccessToken(), is(secondOwner.accessToken));
+  }
+
+  private TestOAuthConnectionState getConnection(String resourceOwnerId) throws Exception {
+    return ((TestOAuthConnection) flowRunner("getConnection")
+        .withVariable(OWNER_ID_VARIABLE_NAME, resourceOwnerId)
+        .run().getMessage().getPayload().getValue()).getState();
+  }
+
+  private static class ResourceOwnerData {
+
+    public String id;
+    public String accessToken;
+    public String refreshToken;
+
+    ResourceOwnerData(String id, String accessToken) {
+      this.id = id;
+      this.accessToken = accessToken;
+      this.refreshToken = accessToken + "-refreshed";
+    }
+  }
+}


### PR DESCRIPTION
(cherry picked from commit a5bbf3f7a66a474a9e514eb9bf687d66bf192aa6)