### PR TITLE
W-10861106: add microbenchmark tests for artifact activation module

### DIFF
--- a/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test;
+
+import org.junit.rules.TemporaryFolder;
+import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
+import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.io.File.separator;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+
+public abstract class AbstractArtifactActivationBenchmark extends AbstractMuleTestCase {
+
+  protected DomainDescriptor customDomainDescriptor;
+  protected File muleHomeFolder;
+  protected TemporaryFolder artifactLocation;
+  protected DefaultArtifactClassLoaderResolver artifactClassLoaderResolver;
+
+  @TearDown
+  public void tearDown() {
+    deleteIfNeeded(getDomainsFolder());
+    deleteIfNeeded(new File(getMuleLibFolder(), "shared"));
+    System.clearProperty(MULE_HOME_DIRECTORY_PROPERTY);
+  }
+
+  protected void deleteIfNeeded(File file) {
+    if (file.exists()) {
+      deleteQuietly(file);
+    }
+  }
+
+  protected DomainDescriptor getTestDomainDescriptor(String name) {
+    DomainDescriptor descriptor = new DomainDescriptor(name);
+    descriptor.setRedeploymentEnabled(false);
+    descriptor.setArtifactLocation(artifactLocation.getRoot());
+    return descriptor;
+  }
+
+  protected File createDomainDir(String domainFolder, String domain) {
+    final File file = new File(muleHomeFolder, domainFolder + separator + domain);
+    assertThat(file.mkdirs(), is(true));
+    return file;
+  }
+
+  protected MuleDeployableArtifactClassLoader getTestDomainClassLoader(List<ArtifactPluginDescriptor> plugins) {
+    customDomainDescriptor.setPlugins(new HashSet<>(plugins));
+    return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+}

--- a/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
@@ -6,6 +6,14 @@
  */
 package org.mule.test;
 
+import static java.io.File.separator;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+
 import org.junit.rules.TemporaryFolder;
 import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
 import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
@@ -17,14 +25,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
-
-import static java.io.File.separator;
-import static org.apache.commons.io.FileUtils.deleteQuietly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
-import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
-import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
 
 public abstract class AbstractArtifactActivationBenchmark extends AbstractMuleTestCase {
 

--- a/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
@@ -6,32 +6,86 @@
  */
 package org.mule.test;
 
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
 import static java.io.File.separator;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
-import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
-import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
 
-import org.junit.rules.TemporaryFolder;
+import org.mule.runtime.container.api.ModuleRepository;
+import org.mule.runtime.container.api.MuleModule;
 import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
+import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.rules.TemporaryFolder;
+
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 
 public abstract class AbstractArtifactActivationBenchmark extends AbstractMuleTestCase {
 
+  protected static final String MULE_DOMAIN_FOLDER = "domains";
+  protected static final String GROUP_ID = "org.mule.test";
+  protected static final String PLUGIN_ID1 = "plugin1";
+  protected static final String PLUGIN_ID2 = "plugin2";
+  protected static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID1)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+  protected static final BundleDescriptor PLUGIN2_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID2)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+
   protected DomainDescriptor customDomainDescriptor;
   protected File muleHomeFolder;
   protected TemporaryFolder artifactLocation;
   protected DefaultArtifactClassLoaderResolver artifactClassLoaderResolver;
+  protected MuleModule muleModule;
+  protected List<MuleModule> muleModuleSingletonList;
+
+  protected final ModuleRepository moduleRepository = mock(ModuleRepository.class);
+  protected final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
+  protected final ArtifactPluginDescriptor plugin1Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID1);
+  protected final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID2);
+  protected DefaultArtifactClassLoaderResolver artifactClassLoaderResolverWithModules;
+  protected final ModuleRepository moduleRepositoryWithModules = mock(ModuleRepository.class);
+
+  public void setup() throws IOException {
+    TemporaryFolder temporaryFolder = new TemporaryFolder();
+    artifactLocation = new TemporaryFolder();
+    temporaryFolder.create();
+    artifactLocation.create();
+    muleHomeFolder = temporaryFolder.getRoot();
+    System.setProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
+    artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
+
+    plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
+    plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
+
+    muleModule = mock(MuleModule.class);
+    muleModuleSingletonList = singletonList(muleModule);
+
+    artifactClassLoaderResolverWithModules =
+        spy(new DefaultArtifactClassLoaderResolver(moduleRepositoryWithModules, nativeLibraryFinderFactory));
+    when(moduleRepositoryWithModules.getModules()).thenReturn(muleModuleSingletonList);
+  }
 
   @TearDown
   public void tearDown() {

--- a/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/AbstractArtifactActivationBenchmark.java
@@ -6,17 +6,19 @@
  */
 package org.mule.test;
 
-import static java.util.Collections.singletonList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+
 import static java.io.File.separator;
+import static java.util.Collections.singletonList;
+
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import org.mule.runtime.container.api.ModuleRepository;
 import org.mule.runtime.container.api.MuleModule;
@@ -28,15 +30,13 @@ import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
-import org.junit.rules.TemporaryFolder;
-
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.TearDown;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+
+import org.junit.rules.TemporaryFolder;
+import org.openjdk.jmh.annotations.TearDown;
 
 public abstract class AbstractArtifactActivationBenchmark extends AbstractMuleTestCase {
 

--- a/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
@@ -12,6 +12,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
+
 import static org.mockito.Mockito.when;
 import static org.openjdk.jmh.annotations.Mode.AverageTime;
 import static org.openjdk.jmh.annotations.Scope.Benchmark;
@@ -22,18 +23,19 @@ import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactCl
 import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 
 @Fork(1)
 @OutputTimeUnit(MILLISECONDS)

--- a/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mule.runtime.container.api.ModuleRepository;
+import org.mule.runtime.container.api.MuleModule;
+import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
+import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
+import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDependency;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+import static org.mule.runtime.module.artifact.api.descriptor.BundleScope.COMPILE;
+import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+@State(Scope.Benchmark)
+public class ApplicationClassloaderCreationBenchmark extends AbstractMuleTestCase {
+
+  public static final String MULE_DOMAIN_FOLDER = "domains";
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public TemporaryFolder artifactLocation = new TemporaryFolder();
+
+  @Rule
+  public final SystemProperty muleHomeSystemProperty =
+      new SystemProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
+
+  private static final String PRIVILEGED_PACKAGE = "org.foo.privileged";
+  private static final String GROUP_ID = "org.mule.test";
+  private static final String PLUGIN_ID1 = "plugin1";
+  private static final String PLUGIN_ARTIFACT_ID1 = GROUP_ID + ":" + PLUGIN_ID1;
+  private static final String PLUGIN_ID2 = "plugin2";
+  private static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID1)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+  private static final BundleDescriptor PLUGIN2_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID2)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+
+  private final ArtifactPluginDescriptor plugin1Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID1);
+  private final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID2);
+  private File muleHomeFolder;
+
+  private DefaultArtifactClassLoaderResolver artifactClassLoaderResolver;
+  private final ModuleRepository moduleRepository = mock(ModuleRepository.class);
+  private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
+  private DomainDescriptor defaultDomainDescriptor;
+  private final String customDomainName = "custom-domain";
+  private final String onlyDomainPackageName = "domain-package";
+  private final String repeatedPackageName = "module&domain-package";
+  private final String applicationName = "app";
+  private DomainDescriptor customDomainDescriptor;
+  private Set<String> domainExportedPackage;
+  private List<ArtifactPluginDescriptor> artifactPluginDescriptors;
+  private ApplicationDescriptor applicationDescriptor;
+  private MuleDeployableArtifactClassLoader customDomainClassLoader;
+
+  @Before
+  public void setup() {
+    muleHomeFolder = temporaryFolder.getRoot();
+    artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
+
+    plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
+    plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
+    defaultDomainDescriptor = getTestDomainDescriptor(DEFAULT_DOMAIN_NAME);
+    customDomainDescriptor = getTestDomainDescriptor(customDomainName);
+    customDomainDescriptor.setRootFolder(createDomainDir(MULE_DOMAIN_FOLDER, customDomainName));
+    MuleModule muleModule = mock(MuleModule.class);
+    when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
+    when(moduleRepository.getModules()).thenReturn(singletonList(muleModule));
+    domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
+    artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toList());
+    applicationDescriptor = new ApplicationDescriptor(applicationName);
+    applicationDescriptor.setArtifactLocation(new File(muleHomeFolder, applicationName));
+    customDomainClassLoader = artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+  @After
+  public void tearDown() {
+    deleteIfNeeded(getDomainsFolder());
+    deleteIfNeeded(new File(getMuleLibFolder(), "shared"));
+  }
+
+  private void deleteIfNeeded(File file) {
+    if (file.exists()) {
+      deleteQuietly(file);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createApplicationClassLoader() {
+    return artifactClassLoaderResolver.createApplicationClassLoader(applicationDescriptor, () -> customDomainClassLoader);
+  }
+
+  @Test
+  public void createApplicationClassLoaderWithExportedPackages() {
+    MuleModule muleModule = mock(MuleModule.class);
+    final String repeatedPackageName = "module&app-package";
+    when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
+    when(moduleRepository.getModules()).thenReturn(singletonList(muleModule));
+    final String onlyAppPackageName = "app-package";
+
+    final MuleDeployableArtifactClassLoader applicationClassLoader =
+        getTestApplicationClassLoader(emptyList(), Stream.of(onlyAppPackageName, repeatedPackageName).collect(toSet()));
+  }
+
+  @Test
+  public void createApplicationClassLoaderWithPlugins() {
+    final MuleDeployableArtifactClassLoader applicationClassLoader =
+        getTestApplicationClassLoader(Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toList()));
+  }
+
+  @Test
+  public void createApplicationClassLoaderWithCachedPlugin() {
+    MuleDeployableArtifactClassLoader applicationClassLoader =
+        getTestApplicationClassLoader(emptyList());
+
+    final ApplicationDescriptor newApplicationDescriptor = applicationClassLoader.getArtifactDescriptor();
+    newApplicationDescriptor.setPlugins(Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet()));
+
+    final MuleArtifactClassLoader domainClassLoader = (MuleArtifactClassLoader) applicationClassLoader.getParent().getParent();
+
+    final MuleArtifactClassLoader plugin2ClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(applicationClassLoader, plugin2Descriptor,
+                                     d -> empty());
+
+    applicationClassLoader =
+        artifactClassLoaderResolver.createApplicationClassLoader(newApplicationDescriptor,
+                                                                 () -> domainClassLoader,
+                                                                 (ownerClassLoader, pluginDescriptor) -> {
+                                                                   if (pluginDescriptor
+                                                                       .getBundleDescriptor()
+                                                                       .getArtifactId()
+                                                                       .equals(plugin2Descriptor
+                                                                           .getBundleDescriptor()
+                                                                           .getArtifactId())) {
+                                                                     return of(() -> plugin2ClassLoader);
+                                                                   } else {
+                                                                     return empty();
+                                                                   }
+                                                                 });
+
+
+  }
+
+  private MuleDeployableArtifactClassLoader getTestDomainClassLoader(List<ArtifactPluginDescriptor> plugins) {
+
+    customDomainDescriptor.setPlugins(new HashSet<>(plugins));
+    return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+  private MuleDeployableArtifactClassLoader getTestApplicationClassLoader(List<ArtifactPluginDescriptor> plugins) {
+    return getTestApplicationClassLoader(plugins, emptySet());
+  }
+
+  private MuleDeployableArtifactClassLoader getTestApplicationClassLoader(List<ArtifactPluginDescriptor> plugins,
+                                                                          Set<String> exportedPackages) {
+    final String applicationName = "app";
+    final MuleDeployableArtifactClassLoader domainClassLoader = getTestDomainClassLoader(emptyList());
+
+    ApplicationDescriptor descriptor = new ApplicationDescriptor(applicationName);
+    descriptor.setArtifactLocation(new File(muleHomeFolder, applicationName));
+    descriptor.setPlugins(new HashSet<>(plugins));
+    descriptor.setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(exportedPackages).build());
+
+    return artifactClassLoaderResolver.createApplicationClassLoader(descriptor, () -> domainClassLoader);
+  }
+
+  private DomainDescriptor getTestDomainDescriptor(String name) {
+    DomainDescriptor descriptor = new DomainDescriptor(name);
+    descriptor.setRedeploymentEnabled(false);
+    descriptor.setArtifactLocation(artifactLocation.getRoot());
+    return descriptor;
+  }
+
+  protected File createDomainDir(String domainFolder, String domain) {
+    final File file = new File(muleHomeFolder, domainFolder + File.separator + domain);
+    assertThat(file.mkdirs(), is(true));
+    return file;
+  }
+}

--- a/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
@@ -6,45 +6,12 @@
  */
 package org.mule.test;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mule.runtime.container.api.ModuleRepository;
-import org.mule.runtime.container.api.MuleModule;
-import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
-import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
-import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
-import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
-import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
-import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
-import org.mule.runtime.module.artifact.api.descriptor.BundleDependency;
-import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
-import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
-import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
-import org.mule.tck.junit4.AbstractMuleTestCase;
-import org.mule.tck.junit4.rule.SystemProperty;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
-
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static java.util.stream.Collectors.toList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,29 +22,46 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
-import static org.mule.runtime.module.artifact.api.descriptor.BundleScope.COMPILE;
-import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
 import static org.openjdk.jmh.annotations.Mode.AverageTime;
 
+import org.junit.rules.TemporaryFolder;
+import org.mule.runtime.container.api.ModuleRepository;
+import org.mule.runtime.container.api.MuleModule;
+import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
+import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
+import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Fork(1)
+@OutputTimeUnit(MILLISECONDS)
 @State(Scope.Benchmark)
 public class ApplicationClassloaderCreationBenchmark extends AbstractMuleTestCase {
 
   public static final String MULE_DOMAIN_FOLDER = "domains";
 
-  @ClassRule
-  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public TemporaryFolder artifactLocation = new TemporaryFolder();
-
-  @Rule
-  public final SystemProperty muleHomeSystemProperty =
-      new SystemProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
-
-  private static final String PRIVILEGED_PACKAGE = "org.foo.privileged";
   private static final String GROUP_ID = "org.mule.test";
   private static final String PLUGIN_ID1 = "plugin1";
-  private static final String PLUGIN_ARTIFACT_ID1 = GROUP_ID + ":" + PLUGIN_ID1;
   private static final String PLUGIN_ID2 = "plugin2";
   private static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
       new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
@@ -95,41 +79,52 @@ public class ApplicationClassloaderCreationBenchmark extends AbstractMuleTestCas
   private DefaultArtifactClassLoaderResolver artifactClassLoaderResolver;
   private final ModuleRepository moduleRepository = mock(ModuleRepository.class);
   private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
-  private DomainDescriptor defaultDomainDescriptor;
   private final String customDomainName = "custom-domain";
-  private final String onlyDomainPackageName = "domain-package";
-  private final String repeatedPackageName = "module&domain-package";
+  private final String repeatedPackageName = "module&app-package";
+  private final String onlyAppPackageName = "app-package";
   private final String applicationName = "app";
   private DomainDescriptor customDomainDescriptor;
-  private Set<String> domainExportedPackage;
-  private List<ArtifactPluginDescriptor> artifactPluginDescriptors;
+  private Set<ArtifactPluginDescriptor> artifactPluginDescriptors;
   private ApplicationDescriptor applicationDescriptor;
   private MuleDeployableArtifactClassLoader customDomainClassLoader;
+  private List<MuleModule> muleModuleSingletonList;
+  private TemporaryFolder artifactLocation;
+  private MuleDeployableArtifactClassLoader domainClassLoader;
+  private ClassLoaderModel classLoaderModel;
 
-  @Before
-  public void setup() {
+  @Setup
+  public void setup() throws IOException {
+    TemporaryFolder temporaryFolder = new TemporaryFolder();
+    artifactLocation = new TemporaryFolder();
+    temporaryFolder.create();
+    artifactLocation.create();
     muleHomeFolder = temporaryFolder.getRoot();
+    System.setProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
     artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
 
     plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
     plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
-    defaultDomainDescriptor = getTestDomainDescriptor(DEFAULT_DOMAIN_NAME);
     customDomainDescriptor = getTestDomainDescriptor(customDomainName);
     customDomainDescriptor.setRootFolder(createDomainDir(MULE_DOMAIN_FOLDER, customDomainName));
+
     MuleModule muleModule = mock(MuleModule.class);
     when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
-    when(moduleRepository.getModules()).thenReturn(singletonList(muleModule));
-    domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
-    artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toList());
+    muleModuleSingletonList = singletonList(muleModule);
+
+    artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet());
     applicationDescriptor = new ApplicationDescriptor(applicationName);
     applicationDescriptor.setArtifactLocation(new File(muleHomeFolder, applicationName));
     customDomainClassLoader = artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+    domainClassLoader = getTestDomainClassLoader(emptyList());
+    Set<String> applicationExportedPackage = Stream.of(onlyAppPackageName, repeatedPackageName).collect(toSet());
+    classLoaderModel = new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(applicationExportedPackage).build();
   }
 
-  @After
+  @TearDown
   public void tearDown() {
     deleteIfNeeded(getDomainsFolder());
     deleteIfNeeded(new File(getMuleLibFolder(), "shared"));
+    System.clearProperty(MULE_HOME_DIRECTORY_PROPERTY);
   }
 
   private void deleteIfNeeded(File file) {
@@ -144,31 +139,29 @@ public class ApplicationClassloaderCreationBenchmark extends AbstractMuleTestCas
     return artifactClassLoaderResolver.createApplicationClassLoader(applicationDescriptor, () -> customDomainClassLoader);
   }
 
-  @Test
-  public void createApplicationClassLoaderWithExportedPackages() {
-    MuleModule muleModule = mock(MuleModule.class);
-    final String repeatedPackageName = "module&app-package";
-    when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
-    when(moduleRepository.getModules()).thenReturn(singletonList(muleModule));
-    final String onlyAppPackageName = "app-package";
-
-    final MuleDeployableArtifactClassLoader applicationClassLoader =
-        getTestApplicationClassLoader(emptyList(), Stream.of(onlyAppPackageName, repeatedPackageName).collect(toSet()));
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createApplicationClassLoaderWithExportedPackages() {
+    when(moduleRepository.getModules()).thenReturn(muleModuleSingletonList);
+    applicationDescriptor.setClassLoaderModel(classLoaderModel);
+    return artifactClassLoaderResolver.createApplicationClassLoader(applicationDescriptor, () -> domainClassLoader);
   }
 
-  @Test
-  public void createApplicationClassLoaderWithPlugins() {
-    final MuleDeployableArtifactClassLoader applicationClassLoader =
-        getTestApplicationClassLoader(Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toList()));
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createApplicationClassLoaderWithPlugins() {
+    applicationDescriptor.setPlugins(artifactPluginDescriptors);
+    return artifactClassLoaderResolver.createApplicationClassLoader(applicationDescriptor, () -> domainClassLoader);
   }
 
-  @Test
-  public void createApplicationClassLoaderWithCachedPlugin() {
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createApplicationClassLoaderWithCachedPlugin() {
     MuleDeployableArtifactClassLoader applicationClassLoader =
-        getTestApplicationClassLoader(emptyList());
+        artifactClassLoaderResolver.createApplicationClassLoader(applicationDescriptor, () -> domainClassLoader);
 
     final ApplicationDescriptor newApplicationDescriptor = applicationClassLoader.getArtifactDescriptor();
-    newApplicationDescriptor.setPlugins(Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet()));
+    newApplicationDescriptor.setPlugins(artifactPluginDescriptors);
 
     final MuleArtifactClassLoader domainClassLoader = (MuleArtifactClassLoader) applicationClassLoader.getParent().getParent();
 
@@ -176,46 +169,26 @@ public class ApplicationClassloaderCreationBenchmark extends AbstractMuleTestCas
         .createMulePluginClassLoader(applicationClassLoader, plugin2Descriptor,
                                      d -> empty());
 
-    applicationClassLoader =
-        artifactClassLoaderResolver.createApplicationClassLoader(newApplicationDescriptor,
-                                                                 () -> domainClassLoader,
-                                                                 (ownerClassLoader, pluginDescriptor) -> {
-                                                                   if (pluginDescriptor
-                                                                       .getBundleDescriptor()
-                                                                       .getArtifactId()
-                                                                       .equals(plugin2Descriptor
-                                                                           .getBundleDescriptor()
-                                                                           .getArtifactId())) {
-                                                                     return of(() -> plugin2ClassLoader);
-                                                                   } else {
-                                                                     return empty();
-                                                                   }
-                                                                 });
-
+    return artifactClassLoaderResolver.createApplicationClassLoader(newApplicationDescriptor,
+                                                                    () -> domainClassLoader,
+                                                                    (ownerClassLoader, pluginDescriptor) -> {
+                                                                      if (pluginDescriptor
+                                                                          .getBundleDescriptor()
+                                                                          .getArtifactId()
+                                                                          .equals(plugin2Descriptor
+                                                                              .getBundleDescriptor()
+                                                                              .getArtifactId())) {
+                                                                        return of(() -> plugin2ClassLoader);
+                                                                      } else {
+                                                                        return empty();
+                                                                      }
+                                                                    });
 
   }
 
   private MuleDeployableArtifactClassLoader getTestDomainClassLoader(List<ArtifactPluginDescriptor> plugins) {
-
     customDomainDescriptor.setPlugins(new HashSet<>(plugins));
     return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
-  }
-
-  private MuleDeployableArtifactClassLoader getTestApplicationClassLoader(List<ArtifactPluginDescriptor> plugins) {
-    return getTestApplicationClassLoader(plugins, emptySet());
-  }
-
-  private MuleDeployableArtifactClassLoader getTestApplicationClassLoader(List<ArtifactPluginDescriptor> plugins,
-                                                                          Set<String> exportedPackages) {
-    final String applicationName = "app";
-    final MuleDeployableArtifactClassLoader domainClassLoader = getTestDomainClassLoader(emptyList());
-
-    ApplicationDescriptor descriptor = new ApplicationDescriptor(applicationName);
-    descriptor.setArtifactLocation(new File(muleHomeFolder, applicationName));
-    descriptor.setPlugins(new HashSet<>(plugins));
-    descriptor.setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(exportedPackages).build());
-
-    return artifactClassLoaderResolver.createApplicationClassLoader(descriptor, () -> domainClassLoader);
   }
 
   private DomainDescriptor getTestDomainDescriptor(String name) {

--- a/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/ApplicationClassloaderCreationBenchmark.java
@@ -8,33 +8,24 @@ package org.mule.test;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
 import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
 
-import org.junit.rules.TemporaryFolder;
-import org.mule.runtime.container.api.ModuleRepository;
 import org.mule.runtime.container.api.MuleModule;
-import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
-import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
-import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
@@ -46,28 +37,9 @@ import java.util.stream.Stream;
 
 @Fork(1)
 @OutputTimeUnit(MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Benchmark)
 public class ApplicationClassloaderCreationBenchmark extends AbstractArtifactActivationBenchmark {
 
-  public static final String MULE_DOMAIN_FOLDER = "domains";
-
-  private static final String GROUP_ID = "org.mule.test";
-  private static final String PLUGIN_ID1 = "plugin1";
-  private static final String PLUGIN_ID2 = "plugin2";
-  private static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
-      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
-                                                                        PLUGIN_ID1)
-          .setVersion("1.0").setClassifier("mule-plugin").build();
-  private static final BundleDescriptor PLUGIN2_BUNDLE_DESCRIPTOR =
-      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
-                                                                        PLUGIN_ID2)
-          .setVersion("1.0").setClassifier("mule-plugin").build();
-
-  private final ArtifactPluginDescriptor plugin1Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID1);
-  private final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID2);
-
-  private final ModuleRepository moduleRepository = mock(ModuleRepository.class);
-  private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
   private final String customDomainName = "custom-domain";
   private final String repeatedPackageName = "module&app-package";
   private final String onlyAppPackageName = "app-package";
@@ -84,22 +56,11 @@ public class ApplicationClassloaderCreationBenchmark extends AbstractArtifactAct
 
   @Setup
   public void setup() throws IOException {
-    TemporaryFolder temporaryFolder = new TemporaryFolder();
-    artifactLocation = new TemporaryFolder();
-    temporaryFolder.create();
-    artifactLocation.create();
-    muleHomeFolder = temporaryFolder.getRoot();
-    System.setProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
-    artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
-
-    plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
-    plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
+    super.setup();
     customDomainDescriptor = getTestDomainDescriptor(customDomainName);
     customDomainDescriptor.setRootFolder(createDomainDir(MULE_DOMAIN_FOLDER, customDomainName));
 
-    MuleModule muleModule = mock(MuleModule.class);
     when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
-    muleModuleSingletonList = singletonList(muleModule);
 
     artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet());
     applicationDescriptor = new ApplicationDescriptor(applicationName);
@@ -126,9 +87,9 @@ public class ApplicationClassloaderCreationBenchmark extends AbstractArtifactAct
   @Benchmark
   @BenchmarkMode(AverageTime)
   public MuleDeployableArtifactClassLoader createApplicationClassLoaderWithExportedPackages() {
-    when(moduleRepository.getModules()).thenReturn(muleModuleSingletonList);
     applicationDescriptor.setClassLoaderModel(classLoaderModel);
-    return artifactClassLoaderResolver.createApplicationClassLoader(applicationDescriptor, () -> domainClassLoader);
+    return artifactClassLoaderResolverWithModules.createApplicationClassLoader(applicationDescriptor,
+                                                                               () -> domainClassLoader);
   }
 
   @Benchmark

--- a/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+import org.junit.rules.TemporaryFolder;
+import org.mule.runtime.container.api.ModuleRepository;
+import org.mule.runtime.container.api.MuleModule;
+import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
+import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
+import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Fork(1)
+@OutputTimeUnit(MILLISECONDS)
+@State(Scope.Benchmark)
+public class DomainClassloaderCreationBenchmark extends AbstractMuleTestCase {
+
+  public static final String MULE_DOMAIN_FOLDER = "domains";
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArtifactClassLoaderResolver.class);
+
+  public TemporaryFolder temporaryFolder;
+  public TemporaryFolder artifactLocation;
+
+  private static final String GROUP_ID = "org.mule.test";
+  private static final String PLUGIN_ID1 = "plugin1";
+  private static final String PLUGIN_ID2 = "plugin2";
+  private static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID1)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+  private static final BundleDescriptor PLUGIN2_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID2)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+
+  private final ArtifactPluginDescriptor plugin1Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID1);
+  private final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID2);
+  private File muleHomeFolder;
+
+  private DefaultArtifactClassLoaderResolver artifactClassLoaderResolver;
+  private final ModuleRepository moduleRepository = mock(ModuleRepository.class);
+  private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
+  private DomainDescriptor defaultDomainDescriptor;
+  private final String customDomainName = "custom-domain";
+  private final String onlyDomainPackageName = "domain-package";
+  private final String repeatedPackageName = "module&domain-package";
+  private DomainDescriptor customDomainDescriptor;
+  private Set<String> domainExportedPackage;
+  private Set<ArtifactPluginDescriptor> artifactPluginDescriptors;
+  private ClassLoaderModel classLoaderModel;
+  private List<MuleModule> muleModuleSingletonList;
+
+  @Setup
+  public void setup() throws IOException {
+    temporaryFolder = new TemporaryFolder();
+    artifactLocation = new TemporaryFolder();
+    temporaryFolder.create();
+    artifactLocation.create();
+    muleHomeFolder = temporaryFolder.getRoot();
+    System.setProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
+    artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
+
+    plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
+    plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
+    defaultDomainDescriptor = getTestDomainDescriptor(DEFAULT_DOMAIN_NAME);
+    customDomainDescriptor = getTestDomainDescriptor(customDomainName);
+    customDomainDescriptor.setRootFolder(createDomainDir(MULE_DOMAIN_FOLDER, customDomainName));
+    MuleModule muleModule = mock(MuleModule.class);
+    when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
+    muleModuleSingletonList = singletonList(muleModule);
+    domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
+    artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet());
+    classLoaderModel = new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(domainExportedPackage).build();
+  }
+
+  @TearDown
+  public void tearDown() {
+    deleteIfNeeded(getDomainsFolder());
+    deleteIfNeeded(new File(getMuleLibFolder(), "shared"));
+  }
+
+  private void deleteIfNeeded(File file) {
+    if (file.exists()) {
+      deleteQuietly(file);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createDomainDefaultClassLoader() {
+    return artifactClassLoaderResolver.createDomainClassLoader(defaultDomainDescriptor);
+  }
+
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createDomainClassLoaderWithExportedPackages() {
+    when(moduleRepository.getModules()).thenReturn(muleModuleSingletonList);
+    customDomainDescriptor.setClassLoaderModel(classLoaderModel);
+    return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createDomainClassLoaderWithPlugins() {
+    customDomainDescriptor.setPlugins(artifactPluginDescriptors);
+    return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+  @Benchmark
+  @BenchmarkMode(AverageTime)
+  public MuleDeployableArtifactClassLoader createDomainClassLoaderWithCachedPlugin() {
+    MuleDeployableArtifactClassLoader domainClassLoader =
+        artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+
+    final DomainDescriptor newDomainDescriptor = domainClassLoader.getArtifactDescriptor();
+    newDomainDescriptor.setPlugins(artifactPluginDescriptors);
+
+    final MuleArtifactClassLoader plugin2ClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(domainClassLoader, plugin2Descriptor,
+                                     d -> empty());
+
+    return artifactClassLoaderResolver.createDomainClassLoader(newDomainDescriptor,
+                                                               (ownerClassLoader, pluginDescriptor) -> {
+                                                                 if (pluginDescriptor
+                                                                     .getBundleDescriptor()
+                                                                     .getArtifactId()
+                                                                     .equals(plugin2Descriptor
+                                                                         .getBundleDescriptor()
+                                                                         .getArtifactId())) {
+                                                                   return of(() -> plugin2ClassLoader);
+                                                                 } else {
+                                                                   return empty();
+                                                                 }
+                                                               });
+
+  }
+
+  private DomainDescriptor getTestDomainDescriptor(String name) {
+    DomainDescriptor descriptor = new DomainDescriptor(name);
+    descriptor.setRedeploymentEnabled(false);
+    descriptor.setArtifactLocation(artifactLocation.getRoot());
+    return descriptor;
+  }
+
+  protected File createDomainDir(String domainFolder, String domain) {
+    final File file = new File(muleHomeFolder, domainFolder + File.separator + domain);
+    assertThat(file.mkdirs(), is(true));
+    return file;
+  }
+}

--- a/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
@@ -6,35 +6,26 @@
  */
 package org.mule.test;
 
+import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
+import static org.mockito.Mockito.when;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
-import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
-import static org.openjdk.jmh.annotations.Mode.AverageTime;
 
-import org.junit.rules.TemporaryFolder;
-import org.mule.runtime.container.api.ModuleRepository;
 import org.mule.runtime.container.api.MuleModule;
-import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
-import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
-import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
 import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
@@ -45,28 +36,9 @@ import java.util.stream.Stream;
 
 @Fork(1)
 @OutputTimeUnit(MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Benchmark)
 public class DomainClassloaderCreationBenchmark extends AbstractArtifactActivationBenchmark {
 
-  public static final String MULE_DOMAIN_FOLDER = "domains";
-
-  private static final String GROUP_ID = "org.mule.test";
-  private static final String PLUGIN_ID1 = "plugin1";
-  private static final String PLUGIN_ID2 = "plugin2";
-  private static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
-      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
-                                                                        PLUGIN_ID1)
-          .setVersion("1.0").setClassifier("mule-plugin").build();
-  private static final BundleDescriptor PLUGIN2_BUNDLE_DESCRIPTOR =
-      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
-                                                                        PLUGIN_ID2)
-          .setVersion("1.0").setClassifier("mule-plugin").build();
-
-  private final ArtifactPluginDescriptor plugin1Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID1);
-  private final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID2);
-
-  private final ModuleRepository moduleRepository = mock(ModuleRepository.class);
-  private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
   private DomainDescriptor defaultDomainDescriptor;
   private final String customDomainName = "custom-domain";
   private final String onlyDomainPackageName = "domain-package";
@@ -80,22 +52,11 @@ public class DomainClassloaderCreationBenchmark extends AbstractArtifactActivati
 
   @Setup
   public void setup() throws IOException {
-    TemporaryFolder temporaryFolder = new TemporaryFolder();
-    artifactLocation = new TemporaryFolder();
-    temporaryFolder.create();
-    artifactLocation.create();
-    muleHomeFolder = temporaryFolder.getRoot();
-    System.setProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
-    artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
-
-    plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
-    plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
+    super.setup();
     defaultDomainDescriptor = getTestDomainDescriptor(DEFAULT_DOMAIN_NAME);
     customDomainDescriptor = getTestDomainDescriptor(customDomainName);
     customDomainDescriptor.setRootFolder(createDomainDir(MULE_DOMAIN_FOLDER, customDomainName));
-    MuleModule muleModule = mock(MuleModule.class);
     when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
-    muleModuleSingletonList = singletonList(muleModule);
     Set<String> domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
     artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet());
     classLoaderModel = new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(domainExportedPackage).build();
@@ -116,9 +77,8 @@ public class DomainClassloaderCreationBenchmark extends AbstractArtifactActivati
   @Benchmark
   @BenchmarkMode(AverageTime)
   public MuleDeployableArtifactClassLoader createDomainClassLoaderWithExportedPackages() {
-    when(moduleRepository.getModules()).thenReturn(muleModuleSingletonList);
     customDomainDescriptor.setClassLoaderModel(classLoaderModel);
-    return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+    return artifactClassLoaderResolverWithModules.createDomainClassLoader(customDomainDescriptor);
   }
 
   @Benchmark

--- a/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
@@ -59,10 +59,6 @@ import java.util.stream.Stream;
 public class DomainClassloaderCreationBenchmark extends AbstractMuleTestCase {
 
   public static final String MULE_DOMAIN_FOLDER = "domains";
-  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArtifactClassLoaderResolver.class);
-
-  public TemporaryFolder temporaryFolder;
-  public TemporaryFolder artifactLocation;
 
   private static final String GROUP_ID = "org.mule.test";
   private static final String PLUGIN_ID1 = "plugin1";
@@ -88,14 +84,14 @@ public class DomainClassloaderCreationBenchmark extends AbstractMuleTestCase {
   private final String onlyDomainPackageName = "domain-package";
   private final String repeatedPackageName = "module&domain-package";
   private DomainDescriptor customDomainDescriptor;
-  private Set<String> domainExportedPackage;
   private Set<ArtifactPluginDescriptor> artifactPluginDescriptors;
   private ClassLoaderModel classLoaderModel;
   private List<MuleModule> muleModuleSingletonList;
+  private TemporaryFolder artifactLocation;
 
   @Setup
   public void setup() throws IOException {
-    temporaryFolder = new TemporaryFolder();
+    TemporaryFolder temporaryFolder = new TemporaryFolder();
     artifactLocation = new TemporaryFolder();
     temporaryFolder.create();
     artifactLocation.create();
@@ -111,7 +107,7 @@ public class DomainClassloaderCreationBenchmark extends AbstractMuleTestCase {
     MuleModule muleModule = mock(MuleModule.class);
     when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
     muleModuleSingletonList = singletonList(muleModule);
-    domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
+    Set<String> domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
     artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toSet());
     classLoaderModel = new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(domainExportedPackage).build();
   }
@@ -120,6 +116,7 @@ public class DomainClassloaderCreationBenchmark extends AbstractMuleTestCase {
   public void tearDown() {
     deleteIfNeeded(getDomainsFolder());
     deleteIfNeeded(new File(getMuleLibFolder(), "shared"));
+    System.clearProperty(MULE_HOME_DIRECTORY_PROPERTY);
   }
 
   private void deleteIfNeeded(File file) {

--- a/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/DomainClassloaderCreationBenchmark.java
@@ -7,14 +7,16 @@
 package org.mule.test;
 
 import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
-import static org.mockito.Mockito.when;
-import static org.openjdk.jmh.annotations.Mode.AverageTime;
-import static org.openjdk.jmh.annotations.Scope.Benchmark;
+
 import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
+
+import static org.mockito.Mockito.when;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
 
 import org.mule.runtime.container.api.MuleModule;
 import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
@@ -22,17 +24,18 @@ import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactCl
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
 import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 
 @Fork(1)
 @OutputTimeUnit(MILLISECONDS)

--- a/performance/src/main/java/org/mule/test/PluginClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/PluginClassloaderCreationBenchmark.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mule.runtime.container.api.ModuleRepository;
+import org.mule.runtime.container.api.MuleModule;
+import org.mule.runtime.module.artifact.activation.internal.classloader.DefaultArtifactClassLoaderResolver;
+import org.mule.runtime.module.artifact.activation.internal.nativelib.DefaultNativeLibraryFinderFactory;
+import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDependency;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleLibFolder;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+import static org.mule.runtime.module.artifact.api.descriptor.BundleScope.COMPILE;
+import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+@State(Scope.Benchmark)
+public class PluginClassloaderCreationBenchmark extends AbstractMuleTestCase {
+
+  public static final String MULE_DOMAIN_FOLDER = "domains";
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public TemporaryFolder artifactLocation = new TemporaryFolder();
+
+  @Rule
+  public final SystemProperty muleHomeSystemProperty =
+      new SystemProperty(MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getAbsolutePath());
+
+  private static final String PRIVILEGED_PACKAGE = "org.foo.privileged";
+  private static final String GROUP_ID = "org.mule.test";
+  private static final String PLUGIN_ID1 = "plugin1";
+  private static final String PLUGIN_ARTIFACT_ID1 = GROUP_ID + ":" + PLUGIN_ID1;
+  private static final String PLUGIN_ID2 = "plugin2";
+  private static final BundleDescriptor PLUGIN1_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID1)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+  private static final BundleDescriptor PLUGIN2_BUNDLE_DESCRIPTOR =
+      new BundleDescriptor.Builder().setGroupId(GROUP_ID).setArtifactId(
+                                                                        PLUGIN_ID2)
+          .setVersion("1.0").setClassifier("mule-plugin").build();
+
+  private final ArtifactPluginDescriptor plugin1Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID1);
+  private final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor(PLUGIN_ID2);
+  private File muleHomeFolder;
+
+  private DefaultArtifactClassLoaderResolver artifactClassLoaderResolver;
+  private final ModuleRepository moduleRepository = mock(ModuleRepository.class);
+  private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
+  private DomainDescriptor defaultDomainDescriptor;
+  private final String customDomainName = "custom-domain";
+  private final String onlyDomainPackageName = "domain-package";
+  private final String repeatedPackageName = "module&domain-package";
+  private final String applicationName = "app";
+  private DomainDescriptor customDomainDescriptor;
+  private Set<String> domainExportedPackage;
+  private List<ArtifactPluginDescriptor> artifactPluginDescriptors;
+  private ApplicationDescriptor applicationDescriptor;
+  private MuleDeployableArtifactClassLoader customDomainClassLoader;
+
+  @Before
+  public void setup() {
+    muleHomeFolder = temporaryFolder.getRoot();
+    artifactClassLoaderResolver = spy(new DefaultArtifactClassLoaderResolver(moduleRepository, nativeLibraryFinderFactory));
+
+    plugin1Descriptor.setBundleDescriptor(PLUGIN1_BUNDLE_DESCRIPTOR);
+    plugin2Descriptor.setBundleDescriptor(PLUGIN2_BUNDLE_DESCRIPTOR);
+    defaultDomainDescriptor = getTestDomainDescriptor(DEFAULT_DOMAIN_NAME);
+    customDomainDescriptor = getTestDomainDescriptor(customDomainName);
+    customDomainDescriptor.setRootFolder(createDomainDir(MULE_DOMAIN_FOLDER, customDomainName));
+    MuleModule muleModule = mock(MuleModule.class);
+    when(muleModule.getExportedPackages()).thenReturn(singleton(repeatedPackageName));
+    when(moduleRepository.getModules()).thenReturn(singletonList(muleModule));
+    domainExportedPackage = Stream.of(onlyDomainPackageName, repeatedPackageName).collect(toSet());
+    artifactPluginDescriptors = Stream.of(plugin1Descriptor, plugin2Descriptor).collect(toList());
+    applicationDescriptor = new ApplicationDescriptor(applicationName);
+    applicationDescriptor.setArtifactLocation(new File(muleHomeFolder, applicationName));
+    customDomainClassLoader = artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+  @After
+  public void tearDown() {
+    deleteIfNeeded(getDomainsFolder());
+    deleteIfNeeded(new File(getMuleLibFolder(), "shared"));
+  }
+
+  private void deleteIfNeeded(File file) {
+    if (file.exists()) {
+      deleteQuietly(file);
+    }
+  }
+
+  @Test
+  public void createDependantPluginClassLoader() {
+    MuleDeployableArtifactClassLoader applicationClassLoader = getTestApplicationClassLoader(emptyList());
+    String plugin2ExportedPackage = "plugin2-package";
+    BundleDependency pluginDependency = new BundleDependency.Builder().setScope(COMPILE).setDescriptor(
+                                                                                                       PLUGIN2_BUNDLE_DESCRIPTOR)
+        .setBundleUri(new File("test").toURI())
+        .build();
+    plugin1Descriptor
+        .setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().dependingOn(singleton(pluginDependency)).build());
+    plugin2Descriptor
+        .setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(singleton(plugin2ExportedPackage))
+            .build());
+
+    final MuleArtifactClassLoader pluginClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(applicationClassLoader, plugin1Descriptor,
+                                     d -> of(plugin2Descriptor));
+
+  }
+
+  @Test
+  public void createPluginClassLoaderWithPrivilegedContainerAccess() {
+    MuleDeployableArtifactClassLoader applicationClassLoader = getTestApplicationClassLoader(emptyList());
+
+    MuleModule privilegedModule = mock(MuleModule.class);
+    when(privilegedModule.getPrivilegedArtifacts()).thenReturn(singleton(PLUGIN_ARTIFACT_ID1));
+    when(privilegedModule.getPrivilegedExportedPackages()).thenReturn(singleton(PRIVILEGED_PACKAGE));
+    when(moduleRepository.getModules()).thenReturn(singletonList(privilegedModule));
+
+    final MuleArtifactClassLoader pluginClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(applicationClassLoader, plugin1Descriptor,
+                                     d -> empty());
+
+  }
+
+  @Test
+  public void createsPluginClassLoaderWithPrivilegedPluginAccess() {
+    ClassLoaderModel plugin2ClassLoaderModel = new ClassLoaderModel.ClassLoaderModelBuilder()
+        .exportingPrivilegedPackages(singleton(PRIVILEGED_PACKAGE), singleton(PLUGIN_ARTIFACT_ID1)).build();
+    plugin2Descriptor.setClassLoaderModel(plugin2ClassLoaderModel);
+
+    BundleDependency pluginDependency = new BundleDependency.Builder().setScope(COMPILE).setDescriptor(
+                                                                                                       PLUGIN2_BUNDLE_DESCRIPTOR)
+        .setBundleUri(new File("test").toURI())
+        .build();
+    plugin1Descriptor
+        .setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().dependingOn(singleton(pluginDependency)).build());
+
+    MuleDeployableArtifactClassLoader applicationClassLoader = getTestApplicationClassLoader(singletonList(plugin2Descriptor));
+
+    final MuleArtifactClassLoader pluginClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(applicationClassLoader, plugin1Descriptor,
+                                     d -> of(plugin2Descriptor));
+
+  }
+
+  @Test
+  public void createPluginClassLoaderWithExportedLocalPackage() {
+    MuleDeployableArtifactClassLoader applicationClassLoader = getTestApplicationClassLoader(emptyList());
+    String pluginPackage = "plugin-package";
+
+    ClassLoaderModel plugin2ClassLoaderModel = new ClassLoaderModel.ClassLoaderModelBuilder()
+        .exportingPackages(singleton(pluginPackage)).build();
+    plugin2Descriptor.setClassLoaderModel(plugin2ClassLoaderModel);
+
+    BundleDependency pluginDependency = new BundleDependency.Builder().setScope(COMPILE).setDescriptor(
+                                                                                                       PLUGIN2_BUNDLE_DESCRIPTOR)
+        .setBundleUri(new File("test").toURI())
+        .build();
+    plugin1Descriptor
+        .setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().withLocalPackages(singleton(pluginPackage))
+            .dependingOn(singleton(pluginDependency)).build());
+
+    final MuleArtifactClassLoader pluginClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(applicationClassLoader, plugin1Descriptor,
+                                     d -> of(plugin2Descriptor));
+
+  }
+
+  @Test
+  public void createPluginClassLoaderWithIgnoredLocalPackages() {
+    MuleModule muleModule = mock(MuleModule.class);
+    final String package1Name = "module&plugin-package";
+    final String package2Name = "org.mule.sdk.api.package";
+    when(muleModule.getExportedPackages()).thenReturn(Stream.of(package1Name, package2Name).collect(toSet()));
+    when(moduleRepository.getModules()).thenReturn(singletonList(muleModule));
+
+    MuleDeployableArtifactClassLoader applicationClassLoader = getTestApplicationClassLoader(emptyList());
+
+    plugin1Descriptor
+        .setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder()
+            .withLocalPackages(Stream.of(package1Name, package2Name).collect(toSet())).build());
+
+    final MuleArtifactClassLoader pluginClassLoader = artifactClassLoaderResolver
+        .createMulePluginClassLoader(applicationClassLoader, plugin1Descriptor,
+                                     d -> empty());
+
+  }
+
+  private MuleDeployableArtifactClassLoader getTestDomainClassLoader(List<ArtifactPluginDescriptor> plugins) {
+
+    customDomainDescriptor.setPlugins(new HashSet<>(plugins));
+    return artifactClassLoaderResolver.createDomainClassLoader(customDomainDescriptor);
+  }
+
+  private MuleDeployableArtifactClassLoader getTestApplicationClassLoader(List<ArtifactPluginDescriptor> plugins) {
+    return getTestApplicationClassLoader(plugins, emptySet());
+  }
+
+  private MuleDeployableArtifactClassLoader getTestApplicationClassLoader(List<ArtifactPluginDescriptor> plugins,
+                                                                          Set<String> exportedPackages) {
+    final String applicationName = "app";
+    final MuleDeployableArtifactClassLoader domainClassLoader = getTestDomainClassLoader(emptyList());
+
+    ApplicationDescriptor descriptor = new ApplicationDescriptor(applicationName);
+    descriptor.setArtifactLocation(new File(muleHomeFolder, applicationName));
+    descriptor.setPlugins(new HashSet<>(plugins));
+    descriptor.setClassLoaderModel(new ClassLoaderModel.ClassLoaderModelBuilder().exportingPackages(exportedPackages).build());
+
+    return artifactClassLoaderResolver.createApplicationClassLoader(descriptor, () -> domainClassLoader);
+  }
+
+  private DomainDescriptor getTestDomainDescriptor(String name) {
+    DomainDescriptor descriptor = new DomainDescriptor(name);
+    descriptor.setRedeploymentEnabled(false);
+    descriptor.setArtifactLocation(artifactLocation.getRoot());
+    return descriptor;
+  }
+
+  protected File createDomainDir(String domainFolder, String domain) {
+    final File file = new File(muleHomeFolder, domainFolder + File.separator + domain);
+    assertThat(file.mkdirs(), is(true));
+    return file;
+  }
+}

--- a/performance/src/main/java/org/mule/test/PluginClassloaderCreationBenchmark.java
+++ b/performance/src/main/java/org/mule/test/PluginClassloaderCreationBenchmark.java
@@ -7,11 +7,6 @@
 package org.mule.test;
 
 import static org.mule.runtime.module.artifact.api.descriptor.BundleScope.COMPILE;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.openjdk.jmh.annotations.Mode.AverageTime;
-import static org.openjdk.jmh.annotations.Scope.Benchmark;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -21,6 +16,12 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
 
 import org.mule.runtime.container.api.ModuleRepository;
 import org.mule.runtime.container.api.MuleModule;
@@ -32,12 +33,6 @@ import org.mule.runtime.module.artifact.api.descriptor.ApplicationDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.BundleDependency;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,6 +40,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 
 @Fork(1)
 @OutputTimeUnit(MILLISECONDS)


### PR DESCRIPTION
Results ApplicationClassloaderCreationBenchmark:

- createApplicationClassLoader: 0.080 ± 0.004 ms/op 
- createApplicationClassLoaderWithExportedPackages: 0.084 ± 0.006 ms/op 
- createApplicationClassLoaderWithPlugins: 0.077 ± 0.001 ms/op
- createApplicationClassLoaderWithCachedPlugin: 0.078 ± 0.015 ms/op 

Results PluginClassloaderCreationBenchmark: 

- createDependantPluginClassLoader: 0.006 ±  0.001 ms/op
- createPluginClassLoaderWithExportedLocalPackage: 0.005 ±  0.001 ms/op
- createPluginClassLoaderWithIgnoredLocalPackages: 0.007 ±  0.004 ms/op 
- createPluginClassLoaderWithPrivilegedContainerAccess: 0.009 ±  0.013 ms/op
- createsPluginClassLoaderWithPrivilegedPluginAccess: 0.005 ±  0.001 ms/op

Results DomainClassloaderCreationBenchmark:

- createDomainClassLoaderWithCachedPlugin: 0.153 ± 0.044  ms/op
- createDomainClassLoaderWithExportedPackages: 0.149 ± 0.025  ms/op
- createDomainClassLoaderWithPlugins: 0.123 ± 0.018  ms/op
- createDomainDefaultClassLoader:  0.034 ± 0.068  ms/op