### PR TITLE
W-11090843: Migrate HttpLoggingConfigTestCase from system test

### DIFF
--- a/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
+++ b/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
@@ -11,7 +11,6 @@ import static org.mule.tck.probe.PollingProber.probe;
 import static org.mule.test.allure.AllureConstants.ComponentsFeature.LoggerStory.LOGGER;
 import static org.mule.test.allure.AllureConstants.IntegrationTestsFeature.INTEGRATIONS_TESTS;
 import static org.mule.test.infrastructure.FileContainsInLine.hasLine;
-import static org.mule.test.infrastructure.HasRegex.hasRegex;
 
 import static java.lang.String.format;
 
@@ -22,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.module.deployment.impl.internal.builder.ApplicationFileBuilder;
 import org.mule.runtime.module.deployment.impl.internal.builder.DomainFileBuilder;
+import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.test.infrastructure.deployment.AbstractFakeMuleServerTestCase;
 
 import java.io.File;
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -53,6 +54,14 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
 
   @Rule
   public UseMuleLog4jContextFactory muleLogging = new UseMuleLog4jContextFactory();
+
+  @ClassRule
+  public static SystemProperty customAppDebugLogSystemProperty =
+      new SystemProperty("customAppDebugLogPropertyValue", "Custom Log App logholis");
+
+  @ClassRule
+  public static SystemProperty notCustomAppDebugLogSystemProperty =
+      new SystemProperty("notCustomAppDebugLogPropertyValue", "Not Custom Log App log");
 
   @Override
   public void setUp() throws Exception {
@@ -126,9 +135,6 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
     String customLogAppName = "custom-log-app";
     String notCustomLogAppName = "not-custom-log-app";
 
-    String customAppLog = "Custom Log App log";
-    String notCustomAppLog = "Not Custom Log App log";
-
     ApplicationFileBuilder customLogAppBuilder = new ApplicationFileBuilder(customLogAppName)
         .definedBy("log/custom-config/mule-config.xml")
         .containingResource("log/custom-config/log4j2.xml", "log4j2.xml");
@@ -142,17 +148,17 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
 
     File customAppLogFile =
         new File(muleServer.getLogsDir().toString() + "/mule-app-" + customLogAppName + "-1.0.0-mule-application.log");
-    probe(() -> hasLine(containsString(customAppLog)).matches(customAppLogFile),
-          () -> format("Text '%s' not present in the logs", customAppLog));
-    probe(() -> !hasLine(containsString(notCustomAppLog)).matches(customAppLogFile),
-          () -> format("Text '%s' present in the logs", notCustomAppLog));
+    probe(() -> hasLine(containsString(customAppDebugLogSystemProperty.getValue())).matches(customAppLogFile),
+          () -> format("Text '%s' not present in the logs", customAppDebugLogSystemProperty.getValue()));
+    probe(() -> !hasLine(containsString(notCustomAppDebugLogSystemProperty.getValue())).matches(customAppLogFile),
+          () -> format("Text '%s' present in the logs", notCustomAppDebugLogSystemProperty.getValue()));
 
     File notCustomAppLogFile =
         new File(muleServer.getLogsDir().toString() + "/mule-app-" + notCustomLogAppName + "-1.0.0-mule-application.log");
-    probe(() -> !hasLine(containsString(customAppLog)).matches(notCustomAppLogFile),
-          () -> format("Text '%s' not present in the logs", customAppLog));
-    probe(() -> !hasLine(containsString(notCustomAppLog)).matches(notCustomAppLogFile),
-          () -> format("Text '%s' not present in the logs", notCustomAppLog));
+    probe(() -> !hasLine(containsString(customAppDebugLogSystemProperty.getValue())).matches(notCustomAppLogFile),
+          () -> format("Text '%s' not present in the logs", customAppDebugLogSystemProperty.getValue()));
+    probe(() -> !hasLine(containsString(notCustomAppDebugLogSystemProperty.getValue())).matches(notCustomAppLogFile),
+          () -> format("Text '%s' not present in the logs", notCustomAppDebugLogSystemProperty.getValue()));
   }
 
   private void ensureOnlyDefaultAppender() throws Exception {

--- a/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
+++ b/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
@@ -57,7 +57,7 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
 
   @ClassRule
   public static SystemProperty customAppDebugLogSystemProperty =
-      new SystemProperty("customAppDebugLogPropertyValue", "Custom Log App logholis");
+      new SystemProperty("customAppDebugLogPropertyValue", "Custom Log App log");
 
   @ClassRule
   public static SystemProperty notCustomAppDebugLogSystemProperty =

--- a/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
+++ b/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
@@ -8,6 +8,8 @@ package org.mule.runtime.test.integration.logging;
 
 import static org.mule.runtime.api.util.MuleSystemProperties.MULE_SIMPLE_LOG;
 import static org.mule.tck.probe.PollingProber.probe;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.LoggerStory.LOGGER;
+import static org.mule.test.allure.AllureConstants.IntegrationTestsFeature.INTEGRATIONS_TESTS;
 import static org.mule.test.infrastructure.FileContainsInLine.hasLine;
 import static org.mule.test.infrastructure.HasRegex.hasRegex;
 
@@ -27,6 +29,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -114,7 +119,10 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
   }
 
   @Test
-  public void honorLog4jConfigFileForTwoDifferentApps() throws Exception {
+  @Feature(INTEGRATIONS_TESTS)
+  @Story(LOGGER)
+  @Issue("W-11090843")
+  public void honorLog4jConfigFileForTwoAppsWithDifferentConfiguration() throws Exception {
     String customLogAppName = "custom-log-app";
     String notCustomLogAppName = "not-custom-log-app";
 
@@ -134,7 +142,7 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
 
     File customAppLogFile =
         new File(muleServer.getLogsDir().toString() + "/mule-app-" + customLogAppName + "-1.0.0-mule-application.log");
-    probe(() -> hasLine(containsString(customAppLog)).matches(customAppLogFile),
+    probe(5000, 100, () -> hasLine(containsString(customAppLog)).matches(customAppLogFile),
           () -> format("Text '%s' not present in the logs", customAppLog));
     probe(() -> !hasLine(hasRegex(notCustomAppLog)).matches(customAppLogFile),
           () -> format("Text '%s' present in the logs", notCustomAppLog));

--- a/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
+++ b/logging/src/test/java/org/mule/runtime/test/integration/logging/LogConfigurationTestCase.java
@@ -142,16 +142,16 @@ public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
 
     File customAppLogFile =
         new File(muleServer.getLogsDir().toString() + "/mule-app-" + customLogAppName + "-1.0.0-mule-application.log");
-    probe(5000, 100, () -> hasLine(containsString(customAppLog)).matches(customAppLogFile),
+    probe(() -> hasLine(containsString(customAppLog)).matches(customAppLogFile),
           () -> format("Text '%s' not present in the logs", customAppLog));
-    probe(() -> !hasLine(hasRegex(notCustomAppLog)).matches(customAppLogFile),
+    probe(() -> !hasLine(containsString(notCustomAppLog)).matches(customAppLogFile),
           () -> format("Text '%s' present in the logs", notCustomAppLog));
 
     File notCustomAppLogFile =
         new File(muleServer.getLogsDir().toString() + "/mule-app-" + notCustomLogAppName + "-1.0.0-mule-application.log");
-    probe(() -> !hasLine(hasRegex(customAppLog)).matches(notCustomAppLogFile),
+    probe(() -> !hasLine(containsString(customAppLog)).matches(notCustomAppLogFile),
           () -> format("Text '%s' not present in the logs", customAppLog));
-    probe(() -> !hasLine(hasRegex(notCustomAppLog)).matches(notCustomAppLogFile),
+    probe(() -> !hasLine(containsString(notCustomAppLog)).matches(notCustomAppLogFile),
           () -> format("Text '%s' not present in the logs", notCustomAppLog));
   }
 

--- a/logging/src/test/resources/log/custom-config/log4j2.xml
+++ b/logging/src/test/resources/log/custom-config/log4j2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration shutdownHook="disable">
+    <Loggers>
+        <AsyncLogger name="org.mule.runtime.core.internal.processor.LoggerMessageProcessor" level="DEBUG" />
+        <AsyncLogger name="org.mule.service.http.impl.service.server.grizzly" level="WARN" />
+        <AsyncLogger name="org.mule.runtime.core.internal.event.AbstractEventContext" level="DEBUG"/>
+    </Loggers>
+</Configuration>

--- a/logging/src/test/resources/log/custom-config/log4j2.xml
+++ b/logging/src/test/resources/log/custom-config/log4j2.xml
@@ -2,7 +2,5 @@
 <Configuration shutdownHook="disable">
     <Loggers>
         <AsyncLogger name="org.mule.runtime.core.internal.processor.LoggerMessageProcessor" level="DEBUG" />
-        <AsyncLogger name="org.mule.service.http.impl.service.server.grizzly" level="WARN" />
-        <AsyncLogger name="org.mule.runtime.core.internal.event.AbstractEventContext" level="DEBUG"/>
     </Loggers>
 </Configuration>

--- a/logging/src/test/resources/log/custom-config/mule-config.xml
+++ b/logging/src/test/resources/log/custom-config/mule-config.xml
@@ -10,7 +10,7 @@
             </scheduling-strategy>
         </scheduler>
 
-        <logger message="Custom Log App log" level="DEBUG"/>
+        <logger message="${customAppDebugLogPropertyValue}" level="DEBUG"/>
     </flow>
 
 </mule>

--- a/logging/src/test/resources/log/custom-config/mule-config.xml
+++ b/logging/src/test/resources/log/custom-config/mule-config.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <flow name="logging">
+        <scheduler>
+            <scheduling-strategy >
+                <fixed-frequency timeUnit="DAYS" frequency="1"/>
+            </scheduling-strategy>
+        </scheduler>
+
+        <logger message="Custom Log App log" level="DEBUG"/>
+    </flow>
+
+</mule>

--- a/logging/src/test/resources/log/not-custom-config/mule-config.xml
+++ b/logging/src/test/resources/log/not-custom-config/mule-config.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <flow name="logging">
+        <scheduler>
+            <scheduling-strategy >
+                <fixed-frequency timeUnit="DAYS" frequency="1"/>
+            </scheduling-strategy>
+        </scheduler>
+
+        <logger message="Not Custom Log App log" level="DEBUG"/>
+    </flow>
+
+</mule>

--- a/logging/src/test/resources/log/not-custom-config/mule-config.xml
+++ b/logging/src/test/resources/log/not-custom-config/mule-config.xml
@@ -10,7 +10,7 @@
             </scheduling-strategy>
         </scheduler>
 
-        <logger message="Not Custom Log App log" level="DEBUG"/>
+        <logger message="${notCustomAppDebugLogPropertyValue}" level="DEBUG"/>
     </flow>
 
 </mule>


### PR DESCRIPTION
Since the original system test was actually testing a change in the mule project https://github.com/mulesoft/mule/pull/6265, not the HTTP project, the test was migrated to an integration test which checks that debug logging can be configured per application