### PR TITLE
W-11215958: Fixing typo in tests.

### DIFF
--- a/integration/src/test/java/org/mule/test/routing/ParallelForEachTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/ParallelForEachTestCase.java
@@ -153,7 +153,7 @@ public class ParallelForEachTestCase extends AbstractIntegrationTestCase {
   public void routeWithExpressionException() {
     assertRouteException("routeWithExpressionException",
                          message -> assertThat(message, both(containsString(EXCEPTION_MESSAGE_TITLE_PREFIX)).and(
-                                                                                                                 containsString("1: org.mule.runtime.core.api.expression.ExpressionRuntimeException: \"Script 'invalidExpr ' has errors:"))),
+                                                                                                                 containsString("1: org.mule.runtime.core.api.expression.ExpressionRuntimeException: \"Script 'invalidExpr' has errors:"))),
                          ExpressionRuntimeException.class,
                          EXPRESSION);
   }

--- a/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
@@ -141,7 +141,7 @@ public class ScatterGatherRouterTestCase extends AbstractIntegrationTestCase {
   public void routeWithExpressionException() throws Exception {
     assertRouteException("routeWithExpressionException",
                          message -> assertThat(message, both(containsString(EXCEPTION_MESSAGE_TITLE_PREFIX)).and(
-                                                                                                                 containsString("1: org.mule.runtime.core.api.expression.ExpressionRuntimeException: \"Script 'invalidExpr ' has errors:"))),
+                                                                                                                 containsString("1: org.mule.runtime.core.api.expression.ExpressionRuntimeException: \"Script 'invalidExpr' has errors:"))),
                          ExpressionRuntimeException.class);
   }
 


### PR DESCRIPTION
[This commit](https://github.com/mulesoft/data-weave/commit/462bda4f48950961b61b5f1973860ab100182352#diff-391fefff45fd34179c72b173921a4d7db22a8758055adff4674fcae396721d90R77) fixed a typo in an error message. Now the tests that were replicating the typo need to be fixed.