### PR TITLE
W-11308645: After calling an external SOAP endpoint, Error Objects are generated differently in MRT 4.3.0 and MRT 4.4.0

### DIFF
--- a/integration/src/test/java/org/mule/test/integration/routing/outbound/UntilSuccessfulRetryExhaustedTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/routing/outbound/UntilSuccessfulRetryExhaustedTestCase.java
@@ -6,7 +6,14 @@
  */
 package org.mule.test.integration.routing.outbound;
 
+import static org.mule.runtime.api.util.MuleSystemProperties.SUPPRESS_ERRORS_PROPERTY;
+import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
+import static org.mule.test.allure.AllureConstants.RoutersFeature.UntilSuccessfulStory.UNTIL_SUCCESSFUL;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -15,10 +22,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
-import static org.mule.test.allure.AllureConstants.RoutersFeature.UntilSuccessfulStory.UNTIL_SUCCESSFUL;
 
-import io.qameta.allure.Issue;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.i18n.I18nMessageFactory;
 import org.mule.runtime.api.message.Error;
@@ -27,20 +31,30 @@ import org.mule.runtime.api.util.concurrent.Latch;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyExhaustedException;
 import org.mule.runtime.extension.api.error.MuleErrors;
-import org.mule.tck.junit4.matcher.ErrorTypeMatcher;
-import org.mule.test.AbstractIntegrationTestCase;
-
-import org.junit.Test;
-
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.mule.tests.api.TestQueueManager;
+import org.mule.tck.junit4.matcher.ErrorTypeMatcher;
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.mule.test.AbstractIntegrationTestCase;
+import org.mule.test.runner.RunnerDelegateTo;
+
+import java.util.Collection;
 
 import javax.inject.Inject;
 
+import io.qameta.allure.Issue;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.junit.runners.Parameterized;
+import org.junit.Rule;
+import org.junit.Test;
+
 @Feature(ROUTERS)
 @Story(UNTIL_SUCCESSFUL)
+@RunnerDelegateTo(Parameterized.class)
 public class UntilSuccessfulRetryExhaustedTestCase extends AbstractIntegrationTestCase {
+
+  @Rule
+  public SystemProperty suppressErrors;
 
   @Inject
   private TestQueueManager queueManager;
@@ -48,6 +62,15 @@ public class UntilSuccessfulRetryExhaustedTestCase extends AbstractIntegrationTe
   @Override
   protected String getConfigFile() {
     return "org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml";
+  }
+
+  @Parameterized.Parameters(name = "Suppress errors: {0}")
+  public static Collection<String> parameters() {
+    return asList("true", "false");
+  }
+
+  public UntilSuccessfulRetryExhaustedTestCase(String suppressErrors) {
+    this.suppressErrors = new SystemProperty(SUPPRESS_ERRORS_PROPERTY, suppressErrors);
   }
 
   @Test
@@ -74,36 +97,64 @@ public class UntilSuccessfulRetryExhaustedTestCase extends AbstractIntegrationTe
 
   @Test
   public void onRetryExhaustedCausedByConnectionExceptionErrorTypeMustBeRetryExhausted() throws Exception {
-    flowRunner("retryExhaustedCausedByConnectivityError").withPayload("message")
-        .runExpectingException(ErrorTypeMatcher.errorType(MuleErrors.RETRY_EXHAUSTED));
+    if (isSupressErrors()) {
+      flowRunner("retryExhaustedCausedByConnectivityError").withPayload("message")
+          .runExpectingException(ErrorTypeMatcher.errorType(MuleErrors.RETRY_EXHAUSTED));
+    } else {
+      flowRunner("retryExhaustedCausedByConnectivityError").withPayload("message")
+          .runExpectingException(ErrorTypeMatcher.errorType(MuleErrors.CONNECTIVITY));
+    }
+  }
+
+  private boolean isSupressErrors() {
+    return parseBoolean(suppressErrors.getValue());
   }
 
   @Test
   @Issue("MULE-18041")
   public void retryExhaustedCausedByConnectionExceptionLogCheck() throws Exception {
-    flowRunner("retryExhaustedCausedByConnectivityErrorLogCheck").withPayload("message")
-        .run();
+    if (isSupressErrors()) {
+      flowRunner("retryExhaustedCausedByConnectivityErrorWithSuppressionLogCheck").withPayload("message")
+          .run();
+    } else {
+      flowRunner("retryExhaustedCausedByConnectivityErrorWithoutSuppressionLogCheck").withPayload("message")
+          .run();
+    }
   }
 
   @Test
   @Issue("MULE-18041")
   public void retryExhaustedCausedByNonConnectionExceptionLogCheck() throws Exception {
-    flowRunner("retryExhaustedCausedByNonConnectivityErrorLogCheck").withPayload("message")
-        .run();
+    if (isSupressErrors()) {
+      flowRunner("retryExhaustedCausedByNonConnectivityErrorWithSuppressionLogCheck").withPayload("message")
+          .run();
+    } else {
+      flowRunner("retryExhaustedCausedByNonConnectivityErrorWithoutSuppressionLogCheck").withPayload("message")
+          .run();
+    }
   }
 
   @Test
   @Issue("MULE-18041")
   public void retryExhaustedCausedByMuleRuntimeExceptionLogCheck() throws Exception {
-    flowRunner("retryExhaustedCausedByMuleRuntimeErrorLogCheck").withPayload("message")
-        .run();
+    if (isSupressErrors()) {
+      flowRunner("retryExhaustedCausedByMuleRuntimeErrorWithSuppressionLogCheck").withPayload("message")
+          .run();
+    } else {
+      flowRunner("retryExhaustedCausedByMuleRuntimeErrorWithoutSuppressionLogCheck").withPayload("message")
+          .run();
+    }
   }
 
   @Test
   @Issue("MULE-18562")
   public void retryExhaustedUnsuppressedErrorTypeHandling() throws Exception {
     CoreEvent event = flowRunner("retryExhaustedUnsuppressedErrorTypeHandling").withPayload("message").run();
-    assertThat(event.getMessage().getPayload().getValue(), is("handled"));
+    if (isSupressErrors()) {
+      assertThat(event.getMessage().getPayload().getValue(), is("retry-exhausted-handled"));
+    } else {
+      assertThat(event.getMessage().getPayload().getValue(), is("security-handled"));
+    }
   }
 
   @Test
@@ -119,13 +170,17 @@ public class UntilSuccessfulRetryExhaustedTestCase extends AbstractIntegrationTe
     flowRunner("retryExhaustedErrorWithSuppressionsCheck").withPayload("message").run();
     // Returned error assertions
     Error error = (Error) queueManager.read("dlq", RECEIVE_TIMEOUT, MILLISECONDS).getMessage().getPayload().getValue();
-    assertThat(error.getErrorType().toString(), equalTo("MULE:RETRY_EXHAUSTED"));
     assertThat(error.getCause(), instanceOf(RetryPolicyExhaustedException.class));
     assertThat(error.getDescription(), equalTo("Mule runtime error"));
     assertThat(error.getDetailedDescription(), equalTo("'until-successful' retries exhausted"));
     assertThat(error.getFailingComponent(), containsString("retryExhaustedErrorWithSuppressionsCheck/processors/0"));
     assertThat(error.getErrorMessage(), nullValue());
     assertThat(error.getChildErrors(), empty());
+    if (isSupressErrors()) {
+      assertThat(error.getErrorType().toString(), equalTo("MULE:RETRY_EXHAUSTED"));
+    } else {
+      assertThat(error.getErrorType().toString(), equalTo("MULE:SECURITY"));
+    }
   }
 
   public static class MuleRuntimeError extends MuleRuntimeException {

--- a/integration/src/test/resources/org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml
+++ b/integration/src/test/resources/org/mule/test/integration/routing/outbound/until-successful-retry-exhausted.xml
@@ -35,7 +35,7 @@
         </try>
     </flow>
 
-    <flow name="retryExhaustedCausedByConnectivityErrorLogCheck">
+    <flow name="retryExhaustedCausedByConnectivityErrorWithSuppressionLogCheck">
         <until-successful maxRetries="1" millisBetweenRetries="10">
             <test:processor throwException="true" exceptionToThrow="org.mule.runtime.api.connection.ConnectionException" exceptionText="Connection refused"/>
         </until-successful>
@@ -50,7 +50,21 @@
         </error-handler>
     </flow>
 
-    <flow name="retryExhaustedCausedByNonConnectivityErrorLogCheck">
+    <flow name="retryExhaustedCausedByConnectivityErrorWithoutSuppressionLogCheck">
+        <until-successful maxRetries="1" millisBetweenRetries="10">
+            <raise-error type="MULE:CONNECTIVITY" description="Connection refused"/>
+        </until-successful>
+        <error-handler>
+            <test:on-error-check-log>
+                <test:check-summary>
+                    <test:summary-info key="Error type" value="MULE:CONNECTIVITY"/>
+                    <test:summary-info key="Message" value="'until-successful' retries exhausted"/>
+                </test:check-summary>
+            </test:on-error-check-log>
+        </error-handler>
+    </flow>
+
+    <flow name="retryExhaustedCausedByNonConnectivityErrorWithSuppressionLogCheck">
         <until-successful maxRetries="1" millisBetweenRetries="10">
             <test:processor throwException="true"/>
         </until-successful>
@@ -65,7 +79,21 @@
         </error-handler>
     </flow>
 
-    <flow name="retryExhaustedCausedByMuleRuntimeErrorLogCheck">
+    <flow name="retryExhaustedCausedByNonConnectivityErrorWithoutSuppressionLogCheck">
+        <until-successful maxRetries="1" millisBetweenRetries="10">
+            <raise-error type="APP:EXPECTED" description="Expected error"/>
+        </until-successful>
+        <error-handler>
+            <test:on-error-check-log>
+                <test:check-summary>
+                    <test:summary-info key="Error type" value="APP:EXPECTED"/>
+                    <test:summary-info key="Message" value="'until-successful' retries exhausted"/>
+                </test:check-summary>
+            </test:on-error-check-log>
+        </error-handler>
+    </flow>
+
+    <flow name="retryExhaustedCausedByMuleRuntimeErrorWithSuppressionLogCheck">
         <until-successful maxRetries="1" millisBetweenRetries="10">
             <test:throw exception="org.mule.test.integration.routing.outbound.UntilSuccessfulRetryExhaustedTestCase.MuleRuntimeError" error="SECURITY"/>
         </until-successful>
@@ -80,13 +108,30 @@
         </error-handler>
     </flow>
 
+    <flow name="retryExhaustedCausedByMuleRuntimeErrorWithoutSuppressionLogCheck">
+        <until-successful maxRetries="1" millisBetweenRetries="10">
+            <test:throw exception="org.mule.test.integration.routing.outbound.UntilSuccessfulRetryExhaustedTestCase.MuleRuntimeError" error="SECURITY"/>
+        </until-successful>
+        <error-handler>
+            <test:on-error-check-log>
+                <test:check-summary>
+                    <test:summary-info key="Error type" value="MULE:SECURITY"/>
+                    <test:summary-info key="Message" value="'until-successful' retries exhausted"/>
+                </test:check-summary>
+            </test:on-error-check-log>
+        </error-handler>
+    </flow>
+
     <flow name="retryExhaustedUnsuppressedErrorTypeHandling">
         <until-successful maxRetries="1" millisBetweenRetries="10">
             <test:throw exception="org.mule.test.integration.routing.outbound.UntilSuccessfulRetryExhaustedTestCase.MuleRuntimeError" error="SECURITY"/>
         </until-successful>
         <error-handler>
             <on-error-continue type="MULE:RETRY_EXHAUSTED">
-                <set-payload value="handled"/>
+                <set-payload value="retry-exhausted-handled"/>
+            </on-error-continue>
+            <on-error-continue type="MULE:SECURITY">
+                <set-payload value="security-handled"/>
             </on-error-continue>
         </error-handler>
     </flow>


### PR DESCRIPTION

(cherry picked from commit ddc3b3f2dea7604378e6bf62029fffb714630fd2)