### PR TITLE
W-11603893: Add a test for failing Global function read  in ComponentConfigurationBuilder that prevents app startup

### DIFF
--- a/integration/src/test/java/org/mule/test/integration/spring/ComponentConfigurationFailingGlobalFunctionTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/spring/ComponentConfigurationFailingGlobalFunctionTestCase.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.integration.spring;
+
+import static org.junit.Assert.assertEquals;
+
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.test.AbstractIntegrationTestCase;
+
+import org.junit.Test;
+
+public class ComponentConfigurationFailingGlobalFunctionTestCase extends AbstractIntegrationTestCase {
+
+  private String EXPECTED_PAYLOAD = "Test payload";
+
+  @Override
+  public String getConfigFile() {
+    return "org/mule/test/integration/spring/sampleapp-with-global-fn.xml";
+  }
+
+  @Test
+  public void runFlowWithoutException() throws Exception {
+    CoreEvent event = flowRunner("main-flow").run();
+    String msg = (String) event.getMessage().getPayload().getValue();
+    assertEquals(EXPECTED_PAYLOAD, msg);
+  }
+}

--- a/integration/src/test/resources/org/mule/test/integration/spring/sampleapp-with-global-fn.xml
+++ b/integration/src/test/resources/org/mule/test/integration/spring/sampleapp-with-global-fn.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+	xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+	<error-handler name="DefaultErrorHandler" doc:id="67a492ab-0885-43c8-b11f-705a8dc9d8a8" >
+		<on-error-propagate enableNotifications="true" logException="true" doc:name="On Error Propagate" type="ANY">
+			<flow-ref doc:name="Flow Reference" doc:id="30d43fff-f72d-4431-a9cb-6ea96e55fc87" name="generic-error-handler-subflow" />
+			</on-error-propagate>
+	</error-handler>
+
+	<configuration doc:name="Configuration" doc:id="64c197f9-b4a5-4883-ae62-3cd32f347690" defaultErrorHandler-ref="DefaultErrorHandler">
+        <expression-language>
+            <global-functions>def printHello(){
+					return 'Hello';
+				}</global-functions>
+        </expression-language>
+    </configuration>
+
+	<flow name="main-flow">
+		<flow-ref name="generic-error-handler-subflow"/>
+	</flow>
+
+    <sub-flow name="generic-error-handler-subflow">
+		<logger level="INFO" doc:name="Logger" />
+		<set-payload value="Test payload"/>
+	</sub-flow>
+</mule>


### PR DESCRIPTION
 Support team reported a customer issue

Errors when deploying app with global functions after last release in 4.4.0-20210906

We made a fix in https://github.com/mulesoft/mule/pull/11777
This is an Integration test for the fix, to show that flow runs correctly after the fix.