### PR TITLE
W-12181063: [Global Error Handling] remove the kill switch for enabling the memory fixes in 4.5 (#1912)

### DIFF
--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
@@ -451,7 +451,7 @@ public class ComponentLocationTestCase extends AbstractIntegrationTestCase {
   public void defaultErrorHandler() throws Exception {
     Location defaultErrorHandlerLoggerLocation = Location.builder().globalName("defaultErrorHandler").build();
     Optional<Component> component = configurationComponentLocator.find(defaultErrorHandlerLoggerLocation);
-    assertThat(component.isPresent(), is(false));
+    assertThat(component.isPresent(), is(true));
   }
 
   @Test

--- a/integration/src/test/java/org/mule/test/integration/exceptions/DefaultErrorHandlerLifecycleTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/DefaultErrorHandlerLifecycleTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.test.integration.exceptions;
 
-import static org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler.reuseGlobalErrorHandler;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ErrorHandlingStory.DEFAULT_ERROR_HANDLER;
 
@@ -64,7 +63,6 @@ public class DefaultErrorHandlerLifecycleTestCase extends AbstractIntegrationTes
 
   @BeforeClass
   public static void beforeClass() {
-    reuseGlobalErrorHandler = true;
     previous = componentBuildingDefinitionRegistryFactory;
     componentBuildingDefinitionRegistryFactory = new TestComponentBuildingDefinitionRegistryFactory();
     componentBuildingDefinitionRegistryFactory.setRefreshRuntimeComponentBuildingDefinitions(true);
@@ -72,7 +70,6 @@ public class DefaultErrorHandlerLifecycleTestCase extends AbstractIntegrationTes
 
   @AfterClass
   public static void afterClass() {
-    reuseGlobalErrorHandler = null;
     componentBuildingDefinitionRegistryFactory = previous;
   }
 

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlerLifecycleTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlerLifecycleTestCase.java
@@ -59,6 +59,14 @@ public class ErrorHandlerLifecycleTestCase extends AbstractIntegrationTestCase {
   @Named("flowD")
   private FlowConstruct flowD;
 
+  @Inject
+  @Named("flowE")
+  private FlowConstruct flowE;
+
+  @Inject
+  @Named("flowF")
+  private FlowConstruct flowF;
+
   @Test
   public void testLifecycleErrorHandlerInFlow() throws Exception {
     // Trigger the flows so the lifecycle-trackers are added to the registry
@@ -101,6 +109,15 @@ public class ErrorHandlerLifecycleTestCase extends AbstractIntegrationTestCase {
 
     ((Lifecycle) flowD).stop();
     ((Lifecycle) flowD).dispose();
+
+    assertThat(defaultEhErrorHandlerPhases.contains(Stoppable.PHASE_NAME), is(false));
+    assertThat(defaultEhErrorHandlerPhases.contains(Disposable.PHASE_NAME), is(false));
+
+    ((Lifecycle) flowE).stop();
+    ((Lifecycle) flowE).dispose();
+
+    ((Lifecycle) flowF).stop();
+    ((Lifecycle) flowF).dispose();
 
     assertThat(defaultEhErrorHandlerPhases, containsInRelativeOrder(Stoppable.PHASE_NAME, Disposable.PHASE_NAME));
   }

--- a/integration/src/test/java/org/mule/test/integration/exceptions/GlobalErrorHandlerLifecycleTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/GlobalErrorHandlerLifecycleTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.test.integration.exceptions;
 
-import static org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler.reuseGlobalErrorHandler;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ErrorHandlingStory.GLOBAL_ERROR_HANDLER;
 
@@ -77,7 +76,6 @@ public class GlobalErrorHandlerLifecycleTestCase extends AbstractIntegrationTest
 
   @BeforeClass
   public static void beforeClass() {
-    reuseGlobalErrorHandler = true;
     previous = componentBuildingDefinitionRegistryFactory;
     componentBuildingDefinitionRegistryFactory = new TestComponentBuildingDefinitionRegistryFactory();
     componentBuildingDefinitionRegistryFactory.setRefreshRuntimeComponentBuildingDefinitions(true);
@@ -85,7 +83,6 @@ public class GlobalErrorHandlerLifecycleTestCase extends AbstractIntegrationTest
 
   @AfterClass
   public static void afterClass() {
-    reuseGlobalErrorHandler = null;
     componentBuildingDefinitionRegistryFactory = previous;
   }
 

--- a/integration/src/test/java/org/mule/test/integration/transaction/TransactionRollbackedByOwnerTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/transaction/TransactionRollbackedByOwnerTestCase.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.api.util.MuleSystemProperties.DEFAULT_ERROR_HANDLER_NOT_ROLLBACK_IF_NOT_CORRESPONDING_PROPERTY;
-import static org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY;
 
 import org.junit.Rule;
 import org.mule.runtime.api.notification.TransactionNotification;
@@ -43,10 +42,6 @@ public class TransactionRollbackedByOwnerTestCase extends AbstractIntegrationTes
   @Rule
   public SystemProperty defaultErrorHandler =
       new SystemProperty(DEFAULT_ERROR_HANDLER_NOT_ROLLBACK_IF_NOT_CORRESPONDING_PROPERTY, "true");
-
-  @Rule
-  public SystemProperty reuseGlobal =
-      new SystemProperty(REUSE_GLOBAL_ERROR_HANDLER_PROPERTY, "true");
 
   @Parameters(name = "{0} - {2}")
   public static Object[][] params() {


### PR DESCRIPTION
(cherry picked from commit 4891022f17af6e99db515b57be09a9b3a3d7dc9e)