### PR TITLE
W-12218381: [Global Error Handling] remove the system property reuse.globalErrorHandler in 4.3/4.4 and replace with a kill switch (#1913)

### DIFF
--- a/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
+++ b/integration/src/test/java/org/mule/test/core/context/notification/processors/ComponentLocationTestCase.java
@@ -443,7 +443,7 @@ public class ComponentLocationTestCase extends AbstractIntegrationTestCase {
   public void defaultErrorHandler() throws Exception {
     Location defaultErrorHandlerLoggerLocation = Location.builder().globalName("defaultErrorHandler").build();
     Optional<Component> component = configurationComponentLocator.find(defaultErrorHandlerLoggerLocation);
-    assertThat(component.isPresent(), is(false));
+    assertThat(component.isPresent(), is(true));
   }
 
   @Test

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlerLifecycleTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ErrorHandlerLifecycleTestCase.java
@@ -80,8 +80,11 @@ public class ErrorHandlerLifecycleTestCase extends AbstractIntegrationTestCase {
     assertThat(lifecycleCheckerMessageProcessorFlowC.isInitialized(), is(true));
     assertThat(lifecycleCheckerMessageProcessorFlowD.isInitialized(), is(true));
     ((Lifecycle) flowC).stop();
-    assertThat(lifecycleCheckerMessageProcessorFlowC.isStopped(), is(true));
+    assertThat(lifecycleCheckerMessageProcessorFlowC.isStopped(), is(false));
     assertThat(lifecycleCheckerMessageProcessorFlowD.isStopped(), is(false));
+    ((Lifecycle) flowD).stop();
+    assertThat(lifecycleCheckerMessageProcessorFlowC.isStopped(), is(true));
+    assertThat(lifecycleCheckerMessageProcessorFlowD.isStopped(), is(true));
   }
 
   public static class LifecycleCheckerMessageProcessor extends AbstractComponent implements Processor, Lifecycle {


### PR DESCRIPTION
(cherry picked from commit 8a5817aab06efb979085b44862207f6d6ff914e9)