### PR TITLE
W-11747609: Ignore flaky test SoapExtensionWithCustomHeadersTestCase#useServiceProviderWithCustomHeaders (#1802)

### DIFF
--- a/soap-connect/integration-tests/src/test/java/org/mule/it/soap/connect/SoapExtensionWithCustomHeadersTestCase.java
+++ b/soap-connect/integration-tests/src/test/java/org/mule/it/soap/connect/SoapExtensionWithCustomHeadersTestCase.java
@@ -6,14 +6,18 @@
  */
 package org.mule.it.soap.connect;
 
+import static org.mule.service.soap.SoapTestUtils.assertSimilarXml;
+
 import static extension.org.mule.soap.it.Environment.PROD;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mule.service.soap.SoapTestUtils.assertSimilarXml;
+
 import org.mule.runtime.api.message.Message;
 
-import extension.org.mule.soap.it.TestServiceProviderWithCustomHeaders;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import extension.org.mule.soap.it.TestServiceProviderWithCustomHeaders;
 
 public class SoapExtensionWithCustomHeadersTestCase extends AbstractSimpleServiceFunctionalTestCase {
 
@@ -23,6 +27,7 @@ public class SoapExtensionWithCustomHeadersTestCase extends AbstractSimpleServic
   }
 
   @Test
+  @Ignore("W-11747609")
   public void useServiceProviderWithCustomHeaders() throws Exception {
     Message m = flowRunner("customHeaders").keepStreamsOpen().run().getMessage();
     assertSimilarXml("<ns2:noParamsWithHeaderResponse xmlns:ns2=\"http://service.soap.service.mule.org/\">"


### PR DESCRIPTION

(cherry picked from commit 41db9c2a45d8120147053b5835705c2b4e79661d)