### PR TITLE
W-12637937:  AST Validations: Cannot inject required fields with minimal JSR-330 impl

### DIFF
--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -18,7 +18,7 @@
         <activemq.version>5.14.5</activemq.version>
         <javaxJmsApiVersion>2.0.1</javaxJmsApiVersion>
         <jsonassert.version>1.5.2</jsonassert.version>
-        <guice.version>1.5.2</guice.version>
+        <guice.version>5.0.1</guice.version>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
     </properties>
 

--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -18,7 +18,7 @@
         <activemq.version>5.14.5</activemq.version>
         <javaxJmsApiVersion>2.0.1</javaxJmsApiVersion>
         <jsonassert.version>1.5.2</jsonassert.version>
-
+        <guice.version>1.5.2</guice.version>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
     </properties>
 
@@ -282,9 +282,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codejargon.feather</groupId>
-            <artifactId>feather</artifactId>
-            <version>1.0</version>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -61,18 +61,16 @@ import javax.inject.Singleton;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Features;
 import io.qameta.allure.Story;
-import org.codejargon.feather.Feather;
-import org.codejargon.feather.Provides;
+//import org.codejargon.feather.Feather;
+//import org.codejargon.feather.Provides;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-/*
 import com.google.inject.Guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
-*/
 
 /**
  * Provides an example of how code running outside of the Mule Runtime may invoke the AST validations that require a base
@@ -82,52 +80,60 @@ import com.google.inject.Provides;
 @Story(DSL_VALIDATION_STORY)
 public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase {
 
-  /*
-   * class BasicModule extends AbstractModule {
-   * 
-   * @Override protected void configure() { //
-   * bind(FeatureFlaggingService.class).to(DefaultFeatureFlaggingService.class).in(Singleton.class);
-   * bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
-   * bind(ValidationsProvider.class).to(CoreValidationsProvider.class); bind(MuleContext.class).to(DefaultMuleContext.class);
-   * bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
-   * 
-   * bind(Object.class).to(String.class);
-   * 
-   * bind(Transformer.class).to(StringToBoolean.class); }
-   * 
-   * @Provides
-   * 
-   * @Singleton public FeatureFlaggingService provideFeatureFlaggingService() { return new DefaultFeatureFlaggingService("abcd2",
-   * new HashMap<>()); }
-   * 
-   * @Provides
-   * 
-   * @Singleton public ExpressionLanguage expressionLanguage() { return new
-   * WeaveDefaultExpressionLanguageFactoryService(null).create(); }
-   * 
-   * @Provides
-   * 
-   * @Singleton
-   * 
-   * @Named("_compatibilityPluginInstalled") Optional<Object> provideOptionalCompatibilityPluginInstalled(Object object) { return
-   * Optional.of(object); }
-   * 
-   * @Provides
-   * 
-   * @Singleton Optional<FeatureFlaggingService> provideOptionalFeatureFlaggingService(FeatureFlaggingService
-   * featureFlaggingService) { return Optional.of(featureFlaggingService); }
-   * 
-   * 
-   * @Provides
-   * 
-   * @Singleton Collection<Transformer> provideCollectionTransformer() { return new ArrayList<Transformer>(); }
-   * 
-   * @Provides
-   * 
-   * @Singleton List<TransformerResolver> provideListTransformerResolver() { return new ArrayList<TransformerResolver>(); }
-   * 
-   * }
-   */
+  class BasicModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+      // bind(FeatureFlaggingService.class).to(DefaultFeatureFlaggingService.class).in(Singleton.class);
+      bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
+      bind(ValidationsProvider.class).to(CoreValidationsProvider.class);
+      bind(MuleContext.class).to(DefaultMuleContext.class);
+      bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
+
+      bind(Object.class).to(String.class);
+
+      bind(Transformer.class).to(StringToBoolean.class);
+    }
+
+    @Provides
+    @Singleton
+    public FeatureFlaggingService provideFeatureFlaggingService() {
+      return new DefaultFeatureFlaggingService("abcd2", new HashMap<>());
+    }
+
+    @Provides
+    @Singleton
+    public ExpressionLanguage expressionLanguage() {
+      return new WeaveDefaultExpressionLanguageFactoryService(null).create();
+    }
+
+    @Provides
+    @Singleton
+    @Named("_compatibilityPluginInstalled")
+    Optional<Object> provideOptionalCompatibilityPluginInstalled(Object object) {
+      return Optional.of(object);
+    }
+
+    @Provides
+    @Singleton
+    Optional<FeatureFlaggingService> provideOptionalFeatureFlaggingService(FeatureFlaggingService featureFlaggingService) {
+      return Optional.of(featureFlaggingService);
+    }
+
+
+    @Provides
+    @Singleton
+    Collection<Transformer> provideCollectionTransformer() {
+      return new ArrayList<Transformer>();
+    }
+
+    @Provides
+    @Singleton
+    List<TransformerResolver> provideListTransformerResolver() {
+      return new ArrayList<TransformerResolver>();
+    }
+
+  }
 
   private static Set<ExtensionModel> runtimeExtensionModels;
   private DefaultExtensionManager extensionManager;
@@ -157,16 +163,13 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
   }
 
   protected List<ValidationResultItem> doValidate(ArtifactAst ast) throws ConfigurationException {
-    Feather feather = Feather.with(new BaseRegistryForValidationsModule());
-    // Injector injector = Guice.createInjector(new BasicModule());
-
-    /*
-     * ArtifactAstValidator astValidator = validatorBuilder() // .withValidationEnricher(feather::injectFields)
-     * .withValidationEnricher(p -> { }) .build();
-     */
+    // Feather feather = Feather.with(new BaseRegistryForValidationsModule());
+    Injector injector = Guice.createInjector(new BasicModule());
 
     ArtifactAstValidator astValidator = validatorBuilder()
-        .withValidationEnricher(feather::injectFields)
+        // .withValidationEnricher(feather::injectFields)
+        .withValidationEnricher(p -> {
+        })
         .build();
 
     ValidationResult result = astValidator.validate(ast);

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -15,25 +15,47 @@ import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.EXP
 import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
 
 import static java.util.stream.Collectors.toList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.Mockito.mock;
 
+import org.mule.runtime.api.config.FeatureFlaggingService;
 import org.mule.runtime.api.el.ExpressionLanguage;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.ast.api.ArtifactAst;
 import org.mule.runtime.ast.api.validation.ArtifactAstValidator;
 import org.mule.runtime.ast.api.validation.ValidationResult;
 import org.mule.runtime.ast.api.validation.ValidationResultItem;
+import org.mule.runtime.ast.api.validation.ValidationsProvider;
 import org.mule.runtime.ast.api.xml.AstXmlParser;
+//import org.mule.runtime.core.api.Injector;
+
+import org.mule.runtime.config.internal.validation.CoreValidationsProvider;
+import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationException;
+import org.mule.runtime.core.api.el.ExtendedExpressionManager;
+import org.mule.runtime.core.api.transformer.Transformer;
+import org.mule.runtime.core.internal.context.DefaultMuleContext;
+import org.mule.runtime.core.internal.el.DefaultExpressionManager;
+import org.mule.runtime.core.internal.registry.TransformerResolver;
+import org.mule.runtime.core.internal.transformer.DefaultTransformersRegistry;
+import org.mule.runtime.core.internal.transformer.simple.StringToBoolean;
+import org.mule.runtime.core.privileged.transformer.TransformersRegistry;
+import org.mule.runtime.feature.internal.config.DefaultFeatureFlaggingService;
 import org.mule.runtime.module.extension.internal.manager.DefaultExtensionManager;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.weave.v2.el.WeaveDefaultExpressionLanguageFactoryService;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import io.qameta.allure.Feature;
@@ -44,6 +66,13 @@ import org.codejargon.feather.Provides;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+/*
+import com.google.inject.Guice;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+*/
 
 /**
  * Provides an example of how code running outside of the Mule Runtime may invoke the AST validations that require a base
@@ -52,6 +81,53 @@ import org.junit.Test;
 @Features({@Feature(ARTIFACT_AST), @Feature(EXPRESSION_LANGUAGE)})
 @Story(DSL_VALIDATION_STORY)
 public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase {
+
+  /*
+   * class BasicModule extends AbstractModule {
+   * 
+   * @Override protected void configure() { //
+   * bind(FeatureFlaggingService.class).to(DefaultFeatureFlaggingService.class).in(Singleton.class);
+   * bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
+   * bind(ValidationsProvider.class).to(CoreValidationsProvider.class); bind(MuleContext.class).to(DefaultMuleContext.class);
+   * bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
+   * 
+   * bind(Object.class).to(String.class);
+   * 
+   * bind(Transformer.class).to(StringToBoolean.class); }
+   * 
+   * @Provides
+   * 
+   * @Singleton public FeatureFlaggingService provideFeatureFlaggingService() { return new DefaultFeatureFlaggingService("abcd2",
+   * new HashMap<>()); }
+   * 
+   * @Provides
+   * 
+   * @Singleton public ExpressionLanguage expressionLanguage() { return new
+   * WeaveDefaultExpressionLanguageFactoryService(null).create(); }
+   * 
+   * @Provides
+   * 
+   * @Singleton
+   * 
+   * @Named("_compatibilityPluginInstalled") Optional<Object> provideOptionalCompatibilityPluginInstalled(Object object) { return
+   * Optional.of(object); }
+   * 
+   * @Provides
+   * 
+   * @Singleton Optional<FeatureFlaggingService> provideOptionalFeatureFlaggingService(FeatureFlaggingService
+   * featureFlaggingService) { return Optional.of(featureFlaggingService); }
+   * 
+   * 
+   * @Provides
+   * 
+   * @Singleton Collection<Transformer> provideCollectionTransformer() { return new ArrayList<Transformer>(); }
+   * 
+   * @Provides
+   * 
+   * @Singleton List<TransformerResolver> provideListTransformerResolver() { return new ArrayList<TransformerResolver>(); }
+   * 
+   * }
+   */
 
   private static Set<ExtensionModel> runtimeExtensionModels;
   private DefaultExtensionManager extensionManager;
@@ -82,6 +158,12 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
 
   protected List<ValidationResultItem> doValidate(ArtifactAst ast) throws ConfigurationException {
     Feather feather = Feather.with(new BaseRegistryForValidationsModule());
+    // Injector injector = Guice.createInjector(new BasicModule());
+
+    /*
+     * ArtifactAstValidator astValidator = validatorBuilder() // .withValidationEnricher(feather::injectFields)
+     * .withValidationEnricher(p -> { }) .build();
+     */
 
     ArtifactAstValidator astValidator = validatorBuilder()
         .withValidationEnricher(feather::injectFields)

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -56,6 +56,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import io.qameta.allure.Feature;
@@ -80,15 +81,25 @@ import com.google.inject.Provides;
 @Story(DSL_VALIDATION_STORY)
 public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase {
 
+  public static class ExpressionLanguageProvider implements Provider<ExpressionLanguage> {
+
+    @Override
+    public ExpressionLanguage get() {
+      return new WeaveDefaultExpressionLanguageFactoryService(null).create();
+    }
+  }
+
   class BasicModule extends AbstractModule {
 
     @Override
     protected void configure() {
       // bind(FeatureFlaggingService.class).to(DefaultFeatureFlaggingService.class).in(Singleton.class);
+      bind(ExpressionLanguage.class).toProvider(ExpressionLanguageProvider.class);
       bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
       bind(ValidationsProvider.class).to(CoreValidationsProvider.class);
       bind(MuleContext.class).to(DefaultMuleContext.class);
       bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
+
 
       bind(Object.class).to(String.class);
 
@@ -101,11 +112,12 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
       return new DefaultFeatureFlaggingService("abcd2", new HashMap<>());
     }
 
-    @Provides
-    @Singleton
-    public ExpressionLanguage expressionLanguage() {
-      return new WeaveDefaultExpressionLanguageFactoryService(null).create();
-    }
+    /*
+     * @Provides
+     * 
+     * @Singleton public ExpressionLanguage provideExpressionLanguage() { return new
+     * WeaveDefaultExpressionLanguageFactoryService(null).create(); }
+     */
 
     @Provides
     @Singleton

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -32,6 +32,7 @@ import org.mule.runtime.ast.api.validation.ValidationsProvider;
 import org.mule.runtime.ast.api.xml.AstXmlParser;
 //import org.mule.runtime.core.api.Injector;
 
+import org.mule.runtime.ast.internal.validation.DefaultValidatorBuilder;
 import org.mule.runtime.config.internal.validation.CoreValidationsProvider;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationException;
@@ -85,7 +86,9 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
 
     @Override
     public ExpressionLanguage get() {
-      return new WeaveDefaultExpressionLanguageFactoryService(null).create();
+      ExpressionLanguage el = new WeaveDefaultExpressionLanguageFactoryService(null).create();
+      System.out.println("EL" + el);
+      return el;
     }
   }
 
@@ -94,7 +97,7 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
     @Override
     protected void configure() {
       // bind(FeatureFlaggingService.class).to(DefaultFeatureFlaggingService.class).in(Singleton.class);
-      bind(ExpressionLanguage.class).toProvider(ExpressionLanguageProvider.class);
+      bind(ExpressionLanguage.class).toProvider(ExpressionLanguageProvider.class).in(Singleton.class);
       bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
       bind(ValidationsProvider.class).to(CoreValidationsProvider.class);
       bind(MuleContext.class).to(DefaultMuleContext.class);
@@ -115,8 +118,8 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
     /*
      * @Provides
      * 
-     * @Singleton public ExpressionLanguage provideExpressionLanguage() { return new
-     * WeaveDefaultExpressionLanguageFactoryService(null).create(); }
+     * @Singleton public ExpressionLanguage provideExpressionLanguage() { ExpressionLanguage el = new
+     * WeaveDefaultExpressionLanguageFactoryService(null).create(); System.out.println("EL" + el); return el; }
      */
 
     @Provides
@@ -178,11 +181,14 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
     // Feather feather = Feather.with(new BaseRegistryForValidationsModule());
     Injector injector = Guice.createInjector(new BasicModule());
 
-    ArtifactAstValidator astValidator = validatorBuilder()
-        // .withValidationEnricher(feather::injectFields)
+    ArtifactAstValidator astValidator = injector.getInstance(DefaultValidatorBuilder.class)
         .withValidationEnricher(p -> {
         })
         .build();
+    /*
+     * ArtifactAstValidator astValidator = validatorBuilder() // .withValidationEnricher(feather::injectFields)
+     * .withValidationEnricher(p -> { }) .build();
+     */
 
     ValidationResult result = astValidator.validate(ast);
 

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -86,9 +86,11 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
 
   private Injector injector;
 
-  @Rule
-  public SystemProperty systemProperty = new SystemProperty(ENFORCE_EXPRESSION_VALIDATION_PROPERTY, "true");
-
+  /**
+   * This will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI framework,
+   * Guice in this example. Earlier we were using feather and that does not work with Java 17. The way injection done here works
+   * both withh Java 8 and 17
+   */
   class BasicModule extends AbstractModule {
 
     private Map<org.mule.runtime.api.config.Feature, Boolean> featureBooleanMap =
@@ -174,7 +176,7 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
 
   protected List<ValidationResultItem> doValidate(ArtifactAst ast) throws ConfigurationException {
     ArtifactAstValidator astValidator = validatorBuilder()
-        .withValidationEnricher(p -> injector.injectMembers(p))
+        .withValidationEnricher(injector::injectMembers)
         .build();
 
     ValidationResult result = astValidator.validate(ast);

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -6,8 +6,6 @@
  */
 package org.mule.test.config.ast;
 
-import static org.mule.runtime.api.config.MuleRuntimeFeature.ENFORCE_EXPRESSION_VALIDATION;
-import static org.mule.runtime.api.util.MuleSystemProperties.ENFORCE_EXPRESSION_VALIDATION_PROPERTY;
 import static org.mule.runtime.ast.api.util.MuleAstUtils.validatorBuilder;
 import static org.mule.runtime.ast.api.validation.Validation.Level.ERROR;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
@@ -17,51 +15,24 @@ import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.EXP
 import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
 
 import static java.util.stream.Collectors.toList;
-import static java.util.Collections.singletonMap;
 
 import static com.google.inject.Guice.createInjector;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
-import org.mule.runtime.api.config.FeatureFlaggingService;
-import org.mule.runtime.api.el.ExpressionLanguage;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.ast.api.ArtifactAst;
 import org.mule.runtime.ast.api.validation.ArtifactAstValidator;
-import org.mule.runtime.ast.api.validation.ArtifactAstValidatorBuilder;
 import org.mule.runtime.ast.api.validation.ValidationResult;
 import org.mule.runtime.ast.api.validation.ValidationResultItem;
-import org.mule.runtime.ast.api.validation.ValidationsProvider;
 import org.mule.runtime.ast.api.xml.AstXmlParser;
-
-import org.mule.runtime.ast.internal.validation.DefaultValidatorBuilder;
-import org.mule.runtime.config.internal.validation.CoreValidationsProvider;
-import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationException;
-import org.mule.runtime.core.api.el.ExtendedExpressionManager;
-import org.mule.runtime.core.api.transformer.Transformer;
-import org.mule.runtime.core.internal.context.DefaultMuleContext;
-import org.mule.runtime.core.internal.el.DefaultExpressionManager;
-import org.mule.runtime.core.internal.registry.TransformerResolver;
-import org.mule.runtime.core.internal.transformer.DefaultTransformersRegistry;
-import org.mule.runtime.core.internal.transformer.simple.StringToBoolean;
-import org.mule.runtime.core.privileged.transformer.TransformersRegistry;
-import org.mule.runtime.feature.internal.config.DefaultFeatureFlaggingService;
 import org.mule.runtime.module.extension.internal.manager.DefaultExtensionManager;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
-import org.mule.tck.junit4.rule.SystemProperty;
-import org.mule.weave.v2.el.WeaveDefaultExpressionLanguageFactoryService;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-
-import javax.inject.Named;
-import javax.inject.Singleton;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Features;
@@ -70,11 +41,8 @@ import io.qameta.allure.Story;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
-import com.google.inject.Provides;
 
 /**
  * Provides an example of how code running outside of the Mule Runtime may invoke the AST validations that require a base
@@ -85,71 +53,11 @@ import com.google.inject.Provides;
 public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase {
 
   private Injector injector;
-
-  /**
-   * This will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI framework,
-   * Guice in this example. Earlier we were using feather and that does not work with Java 17. The way injection done here works
-   * both withh Java 8 and 17
-   */
-  class BasicModule extends AbstractModule {
-
-    private Map<org.mule.runtime.api.config.Feature, Boolean> featureBooleanMap =
-        singletonMap(ENFORCE_EXPRESSION_VALIDATION, Boolean.valueOf(true));
-
-    @Override
-    protected void configure() {
-      bind(ArtifactAstValidatorBuilder.class).to(DefaultValidatorBuilder.class);
-      bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
-      bind(ValidationsProvider.class).to(CoreValidationsProvider.class);
-      bind(MuleContext.class).to(DefaultMuleContext.class);
-      bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
-      bind(Object.class).to(String.class);
-      bind(Transformer.class).to(StringToBoolean.class);
-    }
-
-    @Provides
-    @Singleton
-    public ExpressionLanguage provideExpressionLanguage() {
-      return new WeaveDefaultExpressionLanguageFactoryService(null).create();
-    }
-
-    @Provides
-    @Singleton
-    public FeatureFlaggingService provideFeatureFlaggingService() {
-      return new DefaultFeatureFlaggingService("abcd", featureBooleanMap);
-    }
-
-    @Provides
-    @Singleton
-    @Named("_compatibilityPluginInstalled")
-    Optional<Object> provideOptionalCompatibilityPluginInstalled(Object object) {
-      return Optional.of(object);
-    }
-
-    @Provides
-    @Singleton
-    Optional<FeatureFlaggingService> provideOptionalFeatureFlaggingService(FeatureFlaggingService featureFlaggingService) {
-      return Optional.of(featureFlaggingService);
-    }
-
-    @Provides
-    @Singleton
-    Collection<Transformer> provideCollectionTransformer() {
-      return new ArrayList<Transformer>();
-    }
-
-    @Provides
-    @Singleton
-    List<TransformerResolver> provideListTransformerResolver() {
-      return new ArrayList<TransformerResolver>();
-    }
-  }
-
   private static Set<ExtensionModel> runtimeExtensionModels;
   private DefaultExtensionManager extensionManager;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     runtimeExtensionModels = discoverRuntimeExtensionModels();
   }
 

--- a/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/ArtifactAstValidationsTestCase.java
@@ -19,6 +19,7 @@ import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DS
 import static java.util.stream.Collectors.toList;
 import static java.util.Collections.singletonMap;
 
+import static com.google.inject.Guice.createInjector;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -71,7 +72,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import com.google.inject.Guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
@@ -101,7 +101,6 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
       bind(ValidationsProvider.class).to(CoreValidationsProvider.class);
       bind(MuleContext.class).to(DefaultMuleContext.class);
       bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
-
       bind(Object.class).to(String.class);
       bind(Transformer.class).to(StringToBoolean.class);
     }
@@ -157,7 +156,7 @@ public class ArtifactAstValidationsTestCase extends AbstractMuleContextTestCase 
     extensionManager = new DefaultExtensionManager();
     muleContext.setExtensionManager(extensionManager);
     initialiseIfNeeded(extensionManager, muleContext);
-    injector = Guice.createInjector(new BasicModule());
+    injector = createInjector(new BasicModule());
   }
 
   @Test

--- a/dsl/src/test/java/org/mule/test/config/ast/BasicModule.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/BasicModule.java
@@ -41,7 +41,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
 /**
- * This will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI framework,
+ * This class will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI framework,
  * Guice in this example. Earlier we were using feather and that does not work with Java 17. The way injection done here works
  * both with Java 8 and 17
  */

--- a/dsl/src/test/java/org/mule/test/config/ast/BasicModule.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/BasicModule.java
@@ -10,6 +10,7 @@ import static org.mule.runtime.api.config.MuleRuntimeFeature.ENFORCE_EXPRESSION_
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
+import static java.util.Optional.of;
 
 import org.mule.runtime.api.config.FeatureFlaggingService;
 import org.mule.runtime.api.el.ExpressionLanguage;
@@ -41,9 +42,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
 /**
- * This class will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI framework,
- * Guice in this example. Earlier we were using feather and that does not work with Java 17. The way injection done here works
- * both with Java 8 and 17
+ * This class will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI
+ * framework, Guice in this example. Earlier we were using feather and that does not work with Java 17. The way injection done
+ * here works both with Java 8 and 17
  */
 class BasicModule extends AbstractModule {
 
@@ -77,13 +78,13 @@ class BasicModule extends AbstractModule {
   @Singleton
   @Named("_compatibilityPluginInstalled")
   public Optional<Object> provideOptionalCompatibilityPluginInstalled(Object object) {
-    return Optional.of(object);
+    return of(object);
   }
 
   @Provides
   @Singleton
   public Optional<FeatureFlaggingService> provideOptionalFeatureFlaggingService(FeatureFlaggingService featureFlaggingService) {
-    return Optional.of(featureFlaggingService);
+    return of(featureFlaggingService);
   }
 
   @Provides

--- a/dsl/src/test/java/org/mule/test/config/ast/BasicModule.java
+++ b/dsl/src/test/java/org/mule/test/config/ast/BasicModule.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.config.ast;
+
+import static org.mule.runtime.api.config.MuleRuntimeFeature.ENFORCE_EXPRESSION_VALIDATION;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonMap;
+
+import org.mule.runtime.api.config.FeatureFlaggingService;
+import org.mule.runtime.api.el.ExpressionLanguage;
+import org.mule.runtime.ast.api.validation.ArtifactAstValidatorBuilder;
+import org.mule.runtime.ast.api.validation.ValidationsProvider;
+import org.mule.runtime.ast.internal.validation.DefaultValidatorBuilder;
+import org.mule.runtime.config.internal.validation.CoreValidationsProvider;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.el.ExtendedExpressionManager;
+import org.mule.runtime.core.api.transformer.Transformer;
+import org.mule.runtime.core.internal.context.DefaultMuleContext;
+import org.mule.runtime.core.internal.el.DefaultExpressionManager;
+import org.mule.runtime.core.internal.registry.TransformerResolver;
+import org.mule.runtime.core.internal.transformer.DefaultTransformersRegistry;
+import org.mule.runtime.core.internal.transformer.simple.StringToBoolean;
+import org.mule.runtime.core.privileged.transformer.TransformersRegistry;
+import org.mule.runtime.feature.internal.config.DefaultFeatureFlaggingService;
+import org.mule.weave.v2.el.WeaveDefaultExpressionLanguageFactoryService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+/**
+ * This will serve as an example of how to inject fields for AST validators in a Java 17 compliant way using some DI framework,
+ * Guice in this example. Earlier we were using feather and that does not work with Java 17. The way injection done here works
+ * both with Java 8 and 17
+ */
+class BasicModule extends AbstractModule {
+
+  private Map<org.mule.runtime.api.config.Feature, Boolean> featureBooleanMap =
+      singletonMap(ENFORCE_EXPRESSION_VALIDATION, Boolean.valueOf(true));
+
+  @Override
+  protected void configure() {
+    bind(ArtifactAstValidatorBuilder.class).to(DefaultValidatorBuilder.class);
+    bind(ExtendedExpressionManager.class).to(DefaultExpressionManager.class);
+    bind(ValidationsProvider.class).to(CoreValidationsProvider.class);
+    bind(MuleContext.class).to(DefaultMuleContext.class);
+    bind(TransformersRegistry.class).to(DefaultTransformersRegistry.class);
+    bind(Object.class).to(String.class);
+    bind(Transformer.class).to(StringToBoolean.class);
+  }
+
+  @Provides
+  @Singleton
+  public ExpressionLanguage provideExpressionLanguage() {
+    return new WeaveDefaultExpressionLanguageFactoryService(null).create();
+  }
+
+  @Provides
+  @Singleton
+  public FeatureFlaggingService provideFeatureFlaggingService() {
+    return new DefaultFeatureFlaggingService("abcd", featureBooleanMap);
+  }
+
+  @Provides
+  @Singleton
+  @Named("_compatibilityPluginInstalled")
+  public Optional<Object> provideOptionalCompatibilityPluginInstalled(Object object) {
+    return Optional.of(object);
+  }
+
+  @Provides
+  @Singleton
+  public Optional<FeatureFlaggingService> provideOptionalFeatureFlaggingService(FeatureFlaggingService featureFlaggingService) {
+    return Optional.of(featureFlaggingService);
+  }
+
+  @Provides
+  @Singleton
+  public Collection<Transformer> provideCollectionTransformer() {
+    return emptyList();
+  }
+
+  @Provides
+  @Singleton
+  public List<TransformerResolver> provideListTransformerResolver() {
+    return emptyList();
+  }
+}
+


### PR DESCRIPTION
AST validations injection is intended to work with the minimal JSR-330 spec, which does not cover java.lang.Optional fields.

ArtifactAstValidationsTestCase uses feather fwk to inject the fields, which is a basic JSR-330 impl.

Before java 17, Feather worked fine with Optional because it could instrospct it and use its internal constructor. In java 17, it can no longer do that.
Replacing Feather with Guice for this test.