### PR TITLE
W-13097526: Replace usages of httpbin with WireMock server

### DIFF
--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryCustomActionTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryCustomActionTestCase.java
@@ -90,6 +90,7 @@ public class XmlSdkProcessorInterceptorFactoryCustomActionTestCase extends MuleA
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
 

--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -68,6 +68,7 @@ public class XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase extend
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryTestCase.java
@@ -99,6 +99,7 @@ public class XmlSdkProcessorInterceptorFactoryTestCase extends MuleArtifactFunct
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ExpressionsOnErrorsTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ExpressionsOnErrorsTestCase.java
@@ -8,15 +8,24 @@ package org.mule.test.integration.exceptions;
 
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ErrorHandlingStory.ERROR_HANDLER;
 
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.qameta.allure.Feature;
@@ -26,6 +35,19 @@ import io.qameta.allure.Story;
 @Feature(ERROR_HANDLING)
 @Story(ERROR_HANDLER)
 public class ExpressionsOnErrorsTestCase extends AbstractIntegrationTestCase {
+
+  @Rule
+  public DynamicPort wireMockPort = new DynamicPort("wireMockPort");
+
+  @Rule
+  public WireMockRule wireMock = new WireMockRule(wireMockConfig()
+      .bindAddress("127.0.0.1")
+      .port(wireMockPort.getNumber()));
+
+  @Before
+  public void setUp() {
+    wireMock.stubFor(get(urlMatching("/500")).willReturn(aResponse().withStatus(500)));
+  }
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryChainTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryChainTestCase.java
@@ -76,6 +76,7 @@ public class ProcessorInterceptorFactoryChainTestCase extends AbstractIntegratio
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryCustomActionTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryCustomActionTestCase.java
@@ -95,6 +95,7 @@ public class ProcessorInterceptorFactoryCustomActionTestCase extends AbstractInt
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -64,6 +64,7 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -97,7 +97,9 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
 
   @Before
   public void setUp() {
+    wireMock.stubFor(get(urlMatching("/200")).willReturn(aResponse().withStatus(200)));
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/resources/org/mule/test/integration/exceptions/expressions-on-errors.xml
+++ b/integration/src/test/resources/org/mule/test/integration/exceptions/expressions-on-errors.xml
@@ -24,7 +24,7 @@
     </flow>
 
     <flow name="infoElementSdkOp">
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/500"/>
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/500"/>
         <error-handler>
             <on-error-continue>
                 <set-payload value="#[error.failingComponent]"/>
@@ -44,7 +44,7 @@
     <http:request-config name="HTTP_Request_configuration"/>
 
     <flow name="infoElementDeprecatedSdkOp">
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/500"/>
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/500"/>
         <error-handler>
             <on-error-continue>
                 <set-payload value="#[message.message.exceptionPayload.info.Element]"/>

--- a/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
+++ b/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
@@ -74,7 +74,7 @@
 
     <flow name="executeKillWithClient">
         <heisenberg:execute-remote-kill extension="HTTP" configName="HTTP_Request_configuration" operation="request" >
-            <heisenberg:parameters>#[{'url': 'https://httpbin.org/status/200'}]</heisenberg:parameters>
+            <heisenberg:parameters>#[{'url': 'http://localhost:${wireMockPort}/200'}]</heisenberg:parameters>
         </heisenberg:execute-remote-kill>
     </flow>
 
@@ -87,7 +87,7 @@
     </flow>
 
     <flow name="flowUnknownStatusCodeHttpRequest">
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/418"/>
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/418"/>
     </flow>
 
     <flow name="loggerWithTemplate">


### PR DESCRIPTION
With this ticket, tests using httpbin were updated except for the case of `OpenTelemetryHttpErrorSemanticConventionAttributesAndNameTestCase`.