### PR TITLE
W-13097526: Fix flaky tests by replacing usages of httpbin with WireMock server

### DIFF
--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryCustomActionTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryCustomActionTestCase.java
@@ -90,6 +90,7 @@ public class XmlSdkProcessorInterceptorFactoryCustomActionTestCase extends MuleA
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
 

--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryCustomActionTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryCustomActionTestCase.java
@@ -6,16 +6,22 @@
  */
 package org.mule.test.integration.interception;
 
+import static org.mule.functional.api.exception.ExpectedError.none;
+import static org.mule.runtime.api.interception.ProcessorInterceptorFactory.INTERCEPTORS_ORDER_REGISTRY_KEY;
+import static org.mule.test.allure.AllureConstants.InterceptonApi.ComponentInterceptionStory.COMPONENT_INTERCEPTION_STORY;
+import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
+import static org.mule.test.allure.AllureConstants.XmlSdk.XML_SDK;
+
 import static java.util.Arrays.asList;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mule.functional.api.exception.ExpectedError.none;
-import static org.mule.runtime.api.interception.ProcessorInterceptorFactory.INTERCEPTORS_ORDER_REGISTRY_KEY;
-import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
-import static org.mule.test.allure.AllureConstants.InterceptonApi.ComponentInterceptionStory.COMPONENT_INTERCEPTION_STORY;
-import static org.mule.test.allure.AllureConstants.XmlSdk.XML_SDK;
 
 import org.mule.functional.api.exception.ExpectedError;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
@@ -26,6 +32,7 @@ import org.mule.runtime.api.interception.ProcessorInterceptor;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory.ProcessorInterceptorOrder;
 import org.mule.runtime.api.interception.ProcessorParameterValue;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.IntegrationTestCaseRunnerConfig;
 import org.mule.test.integration.interception.XmlSdkProcessorInterceptorFactoryTestCase.HasInjectedAttributesInterceptor;
 import org.mule.test.integration.interception.XmlSdkProcessorInterceptorFactoryTestCase.HasInjectedAttributesInterceptorFactory;
@@ -39,17 +46,17 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Features;
+import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
-import io.qameta.allure.Description;
-import io.qameta.allure.Feature;
-import io.qameta.allure.Features;
-import io.qameta.allure.Story;
 
 @Features({@Feature(XML_SDK), @Feature(INTERCEPTION_API)})
 @Story(COMPONENT_INTERCEPTION_STORY)
@@ -71,6 +78,20 @@ public class XmlSdkProcessorInterceptorFactoryCustomActionTestCase extends MuleA
   public static Collection<Object> data() {
     return asList(true, false);
   }
+
+  @Rule
+  public DynamicPort wireMockPort = new DynamicPort("wireMockPort");
+
+  @Rule
+  public WireMockRule wireMock = new WireMockRule(wireMockConfig()
+      .bindAddress("127.0.0.1")
+      .port(wireMockPort.getNumber()));
+
+  @Before
+  public void setUp() {
+    wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+  }
+
 
   @Override
   protected String getConfigFile() {

--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -6,14 +6,20 @@
  */
 package org.mule.test.integration.interception;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.mule.functional.api.exception.ExpectedError.none;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.interception.ProcessorInterceptorFactory.INTERCEPTORS_ORDER_REGISTRY_KEY;
-import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
 import static org.mule.test.allure.AllureConstants.InterceptonApi.ComponentInterceptionStory.COMPONENT_INTERCEPTION_STORY;
+import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
 import static org.mule.test.allure.AllureConstants.XmlSdk.XML_SDK;
+
+import static java.util.Arrays.asList;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.sameInstance;
 
 import org.mule.functional.api.exception.ExpectedError;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
@@ -23,6 +29,7 @@ import org.mule.runtime.api.interception.InterceptionEvent;
 import org.mule.runtime.api.interception.ProcessorInterceptor;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory.ProcessorInterceptorOrder;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.IntegrationTestCaseRunnerConfig;
 
 import java.util.HashMap;
@@ -30,14 +37,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Features;
 import io.qameta.allure.Story;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test robustness of the Mule Runtime with misbehaving interceptors.
@@ -49,6 +56,19 @@ public class XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase extend
 
   @Rule
   public ExpectedError expectedError = none();
+
+  @Rule
+  public DynamicPort wireMockPort = new DynamicPort("wireMockPort");
+
+  @Rule
+  public WireMockRule wireMock = new WireMockRule(wireMockConfig()
+      .bindAddress("127.0.0.1")
+      .port(wireMockPort.getNumber()));
+
+  @Before
+  public void setUp() {
+    wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+  }
 
   @Override
   protected String getConfigFile() {

--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -68,6 +68,7 @@ public class XmlSdkProcessorInterceptorFactoryFailingInterceptorsTestCase extend
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryTestCase.java
+++ b/extensions-xml-support/src/test/java/org/mule/test/integration/interception/XmlSdkProcessorInterceptorFactoryTestCase.java
@@ -99,6 +99,7 @@ public class XmlSdkProcessorInterceptorFactoryTestCase extends MuleArtifactFunct
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/exceptions/ExpressionsOnErrorsTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/exceptions/ExpressionsOnErrorsTestCase.java
@@ -8,15 +8,24 @@ package org.mule.test.integration.exceptions;
 
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ErrorHandlingStory.ERROR_HANDLER;
 
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.qameta.allure.Feature;
@@ -26,6 +35,19 @@ import io.qameta.allure.Story;
 @Feature(ERROR_HANDLING)
 @Story(ERROR_HANDLER)
 public class ExpressionsOnErrorsTestCase extends AbstractIntegrationTestCase {
+
+  @Rule
+  public DynamicPort wireMockPort = new DynamicPort("wireMockPort");
+
+  @Rule
+  public WireMockRule wireMock = new WireMockRule(wireMockConfig()
+      .bindAddress("127.0.0.1")
+      .port(wireMockPort.getNumber()));
+
+  @Before
+  public void setUp() {
+    wireMock.stubFor(get(urlMatching("/500")).willReturn(aResponse().withStatus(500)));
+  }
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryChainTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryChainTestCase.java
@@ -76,6 +76,7 @@ public class ProcessorInterceptorFactoryChainTestCase extends AbstractIntegratio
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryCustomActionTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryCustomActionTestCase.java
@@ -95,6 +95,7 @@ public class ProcessorInterceptorFactoryCustomActionTestCase extends AbstractInt
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -64,6 +64,7 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
   @Before
   public void setUp() {
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryFailingInterceptorsTestCase.java
@@ -6,13 +6,19 @@
  */
 package org.mule.test.integration.interception;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.mule.functional.api.exception.ExpectedError.none;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.interception.ProcessorInterceptorFactory.INTERCEPTORS_ORDER_REGISTRY_KEY;
-import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
 import static org.mule.test.allure.AllureConstants.InterceptonApi.ComponentInterceptionStory.COMPONENT_INTERCEPTION_STORY;
+import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
+
+import static java.util.Arrays.asList;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.sameInstance;
 
 import org.mule.functional.api.exception.ExpectedError;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -21,6 +27,7 @@ import org.mule.runtime.api.interception.InterceptionEvent;
 import org.mule.runtime.api.interception.ProcessorInterceptor;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory.ProcessorInterceptorOrder;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 
 import java.util.HashMap;
@@ -28,13 +35,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test robustness of the Mule Runtime with misbehaving interceptors.
@@ -45,6 +52,19 @@ public class ProcessorInterceptorFactoryFailingInterceptorsTestCase extends Abst
 
   @Rule
   public ExpectedError expectedError = none();
+
+  @Rule
+  public DynamicPort wireMockPort = new DynamicPort("wireMockPort");
+
+  @Rule
+  public WireMockRule wireMock = new WireMockRule(wireMockConfig()
+      .bindAddress("127.0.0.1")
+      .port(wireMockPort.getNumber()));
+
+  @Before
+  public void setUp() {
+    wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+  }
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -97,7 +97,9 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
 
   @Before
   public void setUp() {
+    wireMock.stubFor(get(urlMatching("/200")).willReturn(aResponse().withStatus(200)));
     wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+    wireMock.stubFor(get(urlMatching("/418")).willReturn(aResponse().withStatus(418)));
   }
 
   @Override

--- a/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
+++ b/integration/src/test/java/org/mule/test/integration/interception/ProcessorInterceptorFactoryTestCase.java
@@ -6,9 +6,22 @@
  */
 package org.mule.test.integration.interception;
 
+import static org.mule.functional.api.exception.ExpectedError.none;
+import static org.mule.runtime.api.interception.ProcessorInterceptorFactory.INTERCEPTORS_ORDER_REGISTRY_KEY;
+import static org.mule.tck.junit4.matcher.ErrorTypeMatcher.errorType;
+import static org.mule.test.allure.AllureConstants.InterceptonApi.ComponentInterceptionStory.COMPONENT_INTERCEPTION_STORY;
+import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
+import static org.mule.test.heisenberg.extension.HeisenbergConnectionProvider.getActiveConnections;
+import static org.mule.test.heisenberg.extension.HeisenbergOperations.CALL_GUS_MESSAGE;
+
 import static java.lang.Math.random;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -18,13 +31,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.mule.functional.api.exception.ExpectedError.none;
-import static org.mule.runtime.api.interception.ProcessorInterceptorFactory.INTERCEPTORS_ORDER_REGISTRY_KEY;
-import static org.mule.tck.junit4.matcher.ErrorTypeMatcher.errorType;
-import static org.mule.test.allure.AllureConstants.InterceptonApi.INTERCEPTION_API;
-import static org.mule.test.allure.AllureConstants.InterceptonApi.ComponentInterceptionStory.COMPONENT_INTERCEPTION_STORY;
-import static org.mule.test.heisenberg.extension.HeisenbergConnectionProvider.getActiveConnections;
-import static org.mule.test.heisenberg.extension.HeisenbergOperations.CALL_GUS_MESSAGE;
 
 import org.mule.extension.http.api.request.validator.ResponseValidatorException;
 import org.mule.extension.test.extension.reconnection.ReconnectableConnectionProvider;
@@ -45,6 +51,7 @@ import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.runtime.http.api.HttpService;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 import org.mule.test.heisenberg.extension.HeisenbergExtension;
 import org.mule.test.heisenberg.extension.exception.HeisenbergException;
@@ -63,14 +70,15 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Story;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 @Feature(INTERCEPTION_API)
 @Story(COMPONENT_INTERCEPTION_STORY)
@@ -78,6 +86,19 @@ public class ProcessorInterceptorFactoryTestCase extends AbstractIntegrationTest
 
   @Rule
   public ExpectedError expectedError = none();
+
+  @Rule
+  public DynamicPort wireMockPort = new DynamicPort("wireMockPort");
+
+  @Rule
+  public WireMockRule wireMock = new WireMockRule(wireMockConfig()
+      .bindAddress("127.0.0.1")
+      .port(wireMockPort.getNumber()));
+
+  @Before
+  public void setUp() {
+    wireMock.stubFor(get(urlMatching("/404")).willReturn(aResponse().withStatus(404)));
+  }
 
   @Override
   protected String getConfigFile() {

--- a/integration/src/test/resources/org/mule/test/integration/exceptions/expressions-on-errors.xml
+++ b/integration/src/test/resources/org/mule/test/integration/exceptions/expressions-on-errors.xml
@@ -24,7 +24,7 @@
     </flow>
 
     <flow name="infoElementSdkOp">
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/500"/>
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/500"/>
         <error-handler>
             <on-error-continue>
                 <set-payload value="#[error.failingComponent]"/>
@@ -44,7 +44,7 @@
     <http:request-config name="HTTP_Request_configuration"/>
 
     <flow name="infoElementDeprecatedSdkOp">
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/500"/>
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/500"/>
         <error-handler>
             <on-error-continue>
                 <set-payload value="#[message.message.exceptionPayload.info.Element]"/>

--- a/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
+++ b/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
@@ -74,7 +74,7 @@
 
     <flow name="executeKillWithClient">
         <heisenberg:execute-remote-kill extension="HTTP" configName="HTTP_Request_configuration" operation="request" >
-            <heisenberg:parameters>#[{'url': 'https://httpbin.org/status/200'}]</heisenberg:parameters>
+            <heisenberg:parameters>#[{'url': 'http://localhost:${wireMockPort}/200'}]</heisenberg:parameters>
         </heisenberg:execute-remote-kill>
     </flow>
 
@@ -87,7 +87,7 @@
     </flow>
 
     <flow name="flowUnknownStatusCodeHttpRequest">
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/418"/>
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/418"/>
     </flow>
 
     <flow name="loggerWithTemplate">

--- a/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
+++ b/integration/src/test/resources/org/mule/test/integration/interception/processor-interceptor-factory.xml
@@ -66,7 +66,7 @@
 
     <flow name="operationErrorWithMappings">
         <!-- This test uses http because the original issue couldn't be reproduced with heisenberg:call-gus-fring -->
-        <http:request method="GET" config-ref="HTTP_Request_configuration" url="https://httpbin.org/status/404">
+        <http:request method="GET" config-ref="HTTP_Request_configuration" url="http://localhost:${wireMockPort}/404">
             <error-mapping sourceType="HTTP:NOT_FOUND" targetType="APP:MAPPED_CONNECTIVITY"/>
             <error-mapping targetType="APP:ANYTHING_ELSE" />
         </http:request>

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -186,18 +186,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>1.58</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${apacheHttpClientVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,18 @@
       <version>${muleSdkApiVersion}</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>1.58</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
(cherry picks commits https://github.com/mulesoft/mule-integration-tests/commit/78400c136f9899b9407dd0b6ad3ed0804127d061 and https://github.com/mulesoft/mule-integration-tests/commit/6290a40e101ac186ad7d8ff21bbc6e948844a09b)

Fixes flakiness of `ProcessorInterceptorFactoryTestCase` and related ones.