### PR TITLE
W-13829786: Avoid reading mule-module.properties for modules with module-info

### DIFF
--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -215,11 +215,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-tracer-configuration-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-infrastructure</artifactId>
             <version>${project.version}</version>

--- a/tracing/src/test/java/org/mule/test/components/tracing/OpenTelemetryTracingTestRunnerConfigAnnotation.java
+++ b/tracing/src/test/java/org/mule/test/components/tracing/OpenTelemetryTracingTestRunnerConfigAnnotation.java
@@ -15,8 +15,7 @@ import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
     applicationSharedRuntimeLibs = {
         "org.mule.tests:mule-activemq-broker",
         "org.mule.tests:mule-tests-model",
-        "org.mule.runtime:mule-tracer-exporter-impl",
-        "org.mule.runtime:mule-tracer-configuration-api"
+        "org.mule.runtime:mule-tracer-exporter-impl"
     },
     extraPrivilegedArtifacts = {
         "org.mule.tests:mule-tests-parsers-plugin"


### PR DESCRIPTION
Fixing odd things in this tests that cause them to fail in a more restrictive modularized environment.