### PR TITLE
W-15090719: Remove mule-artifact-ast version as it is already present…

### DIFF
--- a/artifact-ast-tests/old-extension-model-compatibility-test/pom.xml
+++ b/artifact-ast-tests/old-extension-model-compatibility-test/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <javaModuleName>org.mule.test.integration.ast.compatibility</javaModuleName>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
-        <muleArtifactAstSerializerVersion>1.3.0-SNAPSHOT</muleArtifactAstSerializerVersion>
 
         <!-- Uses and old version of the Core Extension Models to simulate a miss-match with the AST and the parser that happened
         in the packager -->
@@ -26,19 +25,16 @@
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-artifact-ast-serialization</artifactId>
-            <version>${muleArtifactAstSerializerVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-artifact-ast-xml-parser</artifactId>
-            <version>${muleArtifactAstSerializerVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-artifact-ast</artifactId>
-            <version>${muleArtifactAstSerializerVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
… in the mule-runtime-bom (#2281)

(cherry picked from commit 4ad763e22f288ec5180eb9700d2f2f034a52f797) (cherry picked from commit 861b8b43a7e8b7d085d56ac0ee6b3f51244bb754)