### PR TITLE
W-15959569: change default Java version in pipeline

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,11 +7,11 @@ additionalConfigFileMetadataProviderList:
   - fileId: mule-runtime-maven-settings-MuleSettings
     variable: org.mule.maven.client.api.SettingsSupplierFactory.userSettings
 projectType: runtime
-jdkTool: OPEN-JDK17
+jdkTool: OPEN-JDK11
 mavenAdditionalArgs: -P!testJdkWithoutXmlModule
 additionalTestConfigs:
   jdk8:
     testJdkTool: OPEN-JDK8
     mavenAdditionalArgs: ''
-  jdk11:
-    testJdkTool: OPEN-JDK11
+  jdk17:
+    testJdkTool: OPEN-JDK17


### PR DESCRIPTION
MUnit doesn't run in Java 17, Java 8 or 11 has to be used in conjunction with the `munit.jvm` property.