### PR TITLE
W-16520932: Update MuleSdkApi to version 0.10.1-SNAPSHOT

### DIFF
--- a/munit-tests/forward-compatibility-extension/pom.xml
+++ b/munit-tests/forward-compatibility-extension/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.mule.sdk</groupId>
             <artifactId>mule-sdk-compatibility-api</artifactId>
-            <version>${mule.sdk.api.version}</version>
+            <version>${mule.sdk.compatibility.api.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
W-16520932: Update MuleSdkApi to version 0.10.1-SNAPSHOT

Manual fix, adds the property mule.sdk.compatibility.api to make it independent from the sdk.api version.