### PR TITLE
W-13603419: Unignore SecureHttpPollingFunctionalTestCase

### DIFF
--- a/security/src/test/java/org/mule/test/spring/security/SecureHttpPollingFunctionalTestCase.java
+++ b/security/src/test/java/org/mule/test/spring/security/SecureHttpPollingFunctionalTestCase.java
@@ -16,28 +16,21 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-import org.junit.runner.RunWith;
 import org.mule.extension.http.api.HttpResponseAttributes;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.notification.SecurityNotification;
 import org.mule.runtime.api.notification.SecurityNotificationListener;
 import org.mule.runtime.api.util.concurrent.Latch;
-import org.mule.tck.junit4.FlakinessDetectorTestRunner;
-import org.mule.tck.junit4.FlakyTest;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.IntegrationTestCaseRunnerConfig;
-import org.mule.test.runner.RunnerDelegateTo;
 import org.mule.tests.api.TestQueueManager;
 
 import javax.inject.Inject;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-//@Ignore("W-13603419")
-@RunnerDelegateTo(FlakinessDetectorTestRunner.class)
 public class SecureHttpPollingFunctionalTestCase extends MuleArtifactFunctionalTestCase
     implements IntegrationTestCaseRunnerConfig {
 
@@ -55,7 +48,6 @@ public class SecureHttpPollingFunctionalTestCase extends MuleArtifactFunctionalT
   }
 
   @Test
-  @FlakyTest(times = 10000)
   public void testPollingHttpConnectorSentCredentials() throws Exception {
     final Latch latch = new Latch();
     notificationListenerRegistry.registerListener(new SecurityNotificationListener<SecurityNotification>() {

--- a/security/src/test/java/org/mule/test/spring/security/SecureHttpPollingFunctionalTestCase.java
+++ b/security/src/test/java/org/mule/test/spring/security/SecureHttpPollingFunctionalTestCase.java
@@ -55,7 +55,7 @@ public class SecureHttpPollingFunctionalTestCase extends MuleArtifactFunctionalT
   }
 
   @Test
-  @FlakyTest(times = 1000)
+  @FlakyTest(times = 10000)
   public void testPollingHttpConnectorSentCredentials() throws Exception {
     final Latch latch = new Latch();
     notificationListenerRegistry.registerListener(new SecurityNotificationListener<SecurityNotification>() {

--- a/security/src/test/java/org/mule/test/spring/security/SecureHttpPollingFunctionalTestCase.java
+++ b/security/src/test/java/org/mule/test/spring/security/SecureHttpPollingFunctionalTestCase.java
@@ -16,14 +16,18 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import org.junit.runner.RunWith;
 import org.mule.extension.http.api.HttpResponseAttributes;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.notification.SecurityNotification;
 import org.mule.runtime.api.notification.SecurityNotificationListener;
 import org.mule.runtime.api.util.concurrent.Latch;
+import org.mule.tck.junit4.FlakinessDetectorTestRunner;
+import org.mule.tck.junit4.FlakyTest;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.IntegrationTestCaseRunnerConfig;
+import org.mule.test.runner.RunnerDelegateTo;
 import org.mule.tests.api.TestQueueManager;
 
 import javax.inject.Inject;
@@ -32,7 +36,8 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-@Ignore("W-13603419")
+//@Ignore("W-13603419")
+@RunnerDelegateTo(FlakinessDetectorTestRunner.class)
 public class SecureHttpPollingFunctionalTestCase extends MuleArtifactFunctionalTestCase
     implements IntegrationTestCaseRunnerConfig {
 
@@ -50,6 +55,7 @@ public class SecureHttpPollingFunctionalTestCase extends MuleArtifactFunctionalT
   }
 
   @Test
+  @FlakyTest(times = 1000)
   public void testPollingHttpConnectorSentCredentials() throws Exception {
     final Latch latch = new Latch();
     notificationListenerRegistry.registerListener(new SecurityNotificationListener<SecurityNotification>() {


### PR DESCRIPTION
[W-13603419](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001TzWi4YAF/view)

Was able to execute this test locally for 1000 times without any failure and 10000 times in the [CI build](https://dragon-ci.kbuild.msap.io/onprem-bravo/job/Mule-runtime/job/Mule-4.x-Validation/job/main/23247/console):




```
02:33:15.672  21:58:36.645 [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.367 s -- in org.mule.test.config.SecurityNamespaceHandlerTestCase
02:33:16.572  21:58:37.248 [INFO] 
02:33:16.572  21:58:37.248 [INFO] Results:
02:33:16.572  21:58:37.248 [INFO] 
02:33:16.572  21:58:37.248 [WARNING] Tests run: 10038, Failures: 0, Errors: 0, Skipped: 4
```