### PR TITLE
W-17572814: fix transaction ownership logic in global error handling (#2619)

### DIFF
--- a/integration/src/test/resources/org/mule/test/integration/transaction/transaction-owner-default-err.xml
+++ b/integration/src/test/resources/org/mule/test/integration/transaction/transaction-owner-default-err.xml
@@ -20,6 +20,30 @@
         </try>
     </flow>
 
+    <flow name="other-rollback">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <raise-error type="APP:EXPECTED"/>
+        </try>
+    </flow>
+
+    <flow name="other-other-rollback">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <flow-ref name="other-rollback"/>
+        </try>
+    </flow>
+
+    <flow name="containing-contained-flow-name">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <raise-error type="APP:EXPECTED"/>
+        </try>
+    </flow>
+
+    <flow name="contained-flow-name">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <flow-ref name="containing-contained-flow-name"/>
+        </try>
+    </flow>
+
     <flow name="rollback-with-error-handler-reference-at-inner-transaction-location">
         <try transactionalAction="BEGIN_OR_JOIN">
             <raise-error type="APP:EXPECTED"/>

--- a/integration/src/test/resources/org/mule/test/integration/transaction/transaction-owner-global-err.xml
+++ b/integration/src/test/resources/org/mule/test/integration/transaction/transaction-owner-global-err.xml
@@ -38,6 +38,34 @@
         </error-handler>
     </flow>
 
+    <flow name="other-rollback">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <raise-error type="APP:EXPECTED"/>
+            <error-handler ref="globalPropagate"/>
+        </try>
+    </flow>
+
+    <flow name="other-other-rollback">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <flow-ref name="other-rollback"/>
+            <error-handler ref="globalPropagate"/>
+        </try>
+    </flow>
+
+    <flow name="containing-contained-flow-name">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <raise-error type="APP:EXPECTED"/>
+            <error-handler ref="globalPropagate"/>
+        </try>
+    </flow>
+
+    <flow name="contained-flow-name">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <flow-ref name="containing-contained-flow-name"/>
+            <error-handler ref="globalPropagate"/>
+        </try>
+    </flow>
+
     <flow name="rollback-with-error-handler-reference-at-inner-transaction-location">
         <try transactionalAction="BEGIN_OR_JOIN">
             <raise-error type="APP:EXPECTED"/>


### PR DESCRIPTION
(cherry picked from commit 1eef61778de435d6bb987c3ecd85a9d1646dad65)