### PR TITLE
W-16941297: SG timeout issue

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -13,6 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <h2Version>2.3.232</h2Version>
         <surefire.module.path>
             ${org.slf4j:slf4j-api:jar}:${org.mule.runtime.boot:mule-module-jpms-utils:jar}
         </surefire.module.path>
@@ -35,6 +36,11 @@
             <artifactId>mule-core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2Version}</version>
         </dependency>
         <dependency>
             <groupId>org.mule.tests</groupId>

--- a/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
+++ b/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
@@ -117,6 +117,13 @@ public class ScatterGatherRouterTestCase extends AbstractIntegrationTestCase {
   }
 
   @Test
+  @Description("Scatter Gather timeout should ensure the underlying resources (like db connection) are cleaned up")
+  public void scatterGatherTimeoutShouldEnsureResourcesAreCleanedUp() throws Exception {
+    expectedException.expectCause(withClassName("org.mule.runtime.core.internal.routing.result.CompositeRoutingException"));
+    flowRunner("select-with-timeout-inside-scatter-gather").run();
+  }
+
+  @Test
   @Description("An error in a route results in a CompositeRoutingException containing details of exceptions.")
   public void routeWithException() throws Exception {
     assertRouteException("routeWithException", EXCEPTION_MESSAGE_TITLE_PREFIX

--- a/integration/src/test/resources/routers/scatter-gather-test.xml
+++ b/integration/src/test/resources/routers/scatter-gather-test.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:db="http://www.mulesoft.org/schema/mule/db"
       xmlns:test-components="http://www.mulesoft.org/schema/mule/test-components"
       xmlns:http="http://www.mulesoft.org/schema/mule/http"
       xmlns="http://www.mulesoft.org/schema/mule/core"
       xsi:schemaLocation="
                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd
                http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
                http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
                http://www.mulesoft.org/schema/mule/test-components http://www.mulesoft.org/schema/mule/test-components/current/mule-test-components.xsd">
@@ -91,6 +93,26 @@
             </route>
             <route>
                 <set-payload value="#[java!org::mule::tck::junit4::AbstractMuleContextTestCase::sleepFor(payload, 10000)]"/>
+            </route>
+        </scatter-gather>
+    </flow>
+
+    <db:config name="config">
+        <db:derby-connection database="test" subsubProtocol="memory" create="true" />
+    </db:config>
+
+    <flow name="select-with-timeout-inside-scatter-gather">
+        <scatter-gather timeout="${scatterGather.timeout}">>
+            <route>
+                <db:select config-ref="config">
+                    <db:sql>select sleep(10)</db:sql>
+                </db:select>
+            </route>
+            <route>
+                <set-payload value="apple"/>
+            </route>
+            <route>
+                <set-payload value="banana"/>
             </route>
         </scatter-gather>
     </flow>

--- a/integration/src/test/resources/routers/scatter-gather-test.xml
+++ b/integration/src/test/resources/routers/scatter-gather-test.xml
@@ -101,8 +101,19 @@
         <db:derby-connection database="test" subsubProtocol="memory" create="true" />
     </db:config>
 
+    <db:config name="H2_Database_Config">
+        <db:generic-connection url="jdbc:h2:mem:~/dummyDB;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE" driverClassName="org.h2.Driver" user="sa" />
+    </db:config>
+
     <flow name="select-with-timeout-inside-scatter-gather">
-        <scatter-gather timeout="${scatterGather.timeout}">>
+        <db:execute-ddl doc:name="Execute DDL" config-ref="H2_Database_Config">
+            <db:sql ><![CDATA[DROP ALIAS IF EXISTS SLEEP]]></db:sql>
+        </db:execute-ddl>
+
+        <db:execute-ddl doc:name="Execute DDL" config-ref="H2_Database_Config">
+            <db:sql ><![CDATA[CREATE ALIAS SLEEP FOR "java.lang.Thread.sleep"]]></db:sql>
+        </db:execute-ddl>
+        <scatter-gather timeout="${scatterGather.timeout}">
             <route>
                 <db:select config-ref="config">
                     <db:sql>select sleep(10)</db:sql>


### PR DESCRIPTION
## Ticket
<!-- Associated GUS ticket(s) -->
[W-16941297](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16941297)

## Description
Attempting to add a test piggybacking on existing SG timeout test and a flow demonstrating use of https://github.com/mulesoft/mule-integration-tests/blob/b0be56518dea9b3e723f3af69e9db732dd5643d5/integration/src/test/resources/lazy-routes.xml#L16-L24

## Alternatives considered
### Derby Database 
Tried using the existing derby database config, and use derby db in embedded mode. However, the derby db doesn't have a SLEEP equivalent function.

There's a potential solution where a Java method that invokes Thread.sleep() could be registered as a UDF (User Defined Function) but that requires a restart and also the classpath property modification. After a successful registration, there is a way to run the sql from java code as below:

```java
String sleepSQL = "VALUES org.example.derby.SleepExample.sleep(2000)";
stmt.executeQuery(sleepSQL);
```
where org.example.derby.SleepExample.sleep is the java method that calls Thread.sleep.

Although in theory it looks very procedural but it may not work for the integration tests because there's seems to be a restart step for an embedded db that runs during the lifetime of the tests. After numerous tries, it felt very uneasy to go down this route. 

### H2 Database
Having H2 database for a test requires adding dependency in the pom for example:

```xml
<dependency>
      <groupId>com.h2database</groupId>
      <artifactId>h2</artifactId>
      <version>2.1.214</version> <!-- Use your preferred version -->
</dependency>
```

## Using the Embedded H2 Database

### DB Config in the mule flow
Make sure to configure the flow with the following db config `H2_Database_Config` and use it in the `db:select`
```xml
<db:config name="H2_Database_Config" doc:name="Database Config" >
	<db:generic-connection url="jdbc:h2:~/dummyDB" driverClassName="org.h2.Driver" user="sa" />
</db:config>
```

### DB Alias for SLEEP
This is needed because like Derby DB, the H2 DB also doesn't have an inbuilt SLEEP function. 
```xml
<db:execute-ddl doc:name="Execute DDL" config-ref="H2_Database_Config">
	<db:sql ><![CDATA[DROP ALIAS IF EXISTS SLEEP]]></db:sql>
</db:execute-ddl>

<db:execute-ddl doc:name="Execute DDL" config-ref="H2_Database_Config">
	<db:sql ><![CDATA[CREATE ALIAS SLEEP FOR "java.lang.Thread.sleep"]]></db:sql>
</db:execute-ddl>
```

### Followed by the `flowRunner` invocation of the test flow that's reproduces the scenario

An oversimplified version. 
```xml
<flow name="select-with-timeout-inside-scatter-gather">
        <scatter-gather timeout="${scatterGather.timeout}">
            <route>
                <db:select config-ref="config">
                    <db:sql>select sleep(10)</db:sql>
                </db:select>
            </route>
            <route>
                <set-payload value="apple"/>
            </route>
        </scatter-gather>
    </flow>
```


### Verification step 
TBD - working on this, a rough idea is to use an `error-handler` in the flow and then execute sql 

```sql
SELECT EXECUTING_STATEMENT FROM INFORMATION_SCHEMA.SESSIONS
```
This is somewhat equivalent to running this in mysql

```sql
show full processlist;
```


