### PR TITLE
[W-17737743] Fix InvalidPathException in Maven Surefire by using path separator property

### DIFF
--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -10,7 +10,7 @@
     
     <properties>
         <surefire.module.path>
-            ${org.slf4j:slf4j-api:jar}:${org.mule.runtime.boot:mule-module-jpms-utils:jar}
+            ${org.slf4j:slf4j-api:jar}${path.separator}${org.mule.runtime.boot:mule-module-jpms-utils:jar}
         </surefire.module.path>
         <surefire.add.modules>
             org.slf4j,org.mule.runtime.jpms.utils


### PR DESCRIPTION
Replaced hardcoded `:` in `<surefire.module.path>` with `${path.separator}` to ensure compatibility across Windows, Linux, and macOS.  