### PR TITLE
W-17802898: Replace lineSeparator() with "\n" to match payload content

### DIFF
--- a/integration/src/test/java/org/mule/runtime/test/integration/properties/DomainPropertiesPlaceHolderPropagationTestCase.java
+++ b/integration/src/test/java/org/mule/runtime/test/integration/properties/DomainPropertiesPlaceHolderPropagationTestCase.java
@@ -60,7 +60,7 @@ public class DomainPropertiesPlaceHolderPropagationTestCase extends AbstractMule
     String appPropertyObject = getApplicationProperty("appPropertyObject");
     assertThat(appPropertyObject, is("9999"));
     String inlinePropertyObject = getApplicationProperty("inlinePropertyObject");
-    assertThat(inlinePropertyObject, is("file contents" + lineSeparator()));
+    assertThat(inlinePropertyObject, is("file contents\n"));
   }
 
   private String getApplicationProperty(String property) {

--- a/integration/src/test/java/org/mule/test/processors/ParseTemplateTestCase.java
+++ b/integration/src/test/java/org/mule/test/processors/ParseTemplateTestCase.java
@@ -233,9 +233,9 @@ public class ParseTemplateTestCase extends AbstractIntegrationTestCase {
   @Test
   public void subexpressionsExampleFromDocs() throws Exception {
     CoreEvent event = flowRunner("subexpressionsExampleFromDocs").run();
-    assertThat(event.getMessage().getPayload().getValue(), equalTo("<td>hello WORLD</td>" + lineSeparator()
-        + "<td>hello WORLD</td>" + lineSeparator()
-        + "<td>hello upper(\"world\")</td>" + lineSeparator()
+    assertThat(event.getMessage().getPayload().getValue(), equalTo("<td>hello WORLD</td>\n"
+        + "<td>hello WORLD</td>\n"
+        + "<td>hello upper(\"world\")</td>\n"
         + "<td>hello ++ upper(\"world\")</td>"));
   }
 
@@ -244,12 +244,12 @@ public class ParseTemplateTestCase extends AbstractIntegrationTestCase {
     CoreEvent event = flowRunner("escapeExampleFromDocs").run();
 
     // Current behavior here has [JKL] preceded by the escape character in the result which is not what we have in the docs
-    assertThat(event.getMessage().getPayload().getValue(), equalTo("<td>#[</td>" + lineSeparator()
-        + "<td>abcd#[-1234WORLD.log</td>" + lineSeparator()
-        + "<td>'abc'def'</td>" + lineSeparator()
-        + "<td>abc'def</td>" + lineSeparator()
-        + "<td>\"xyz\"xyz\"</td>" + lineSeparator()
-        + "<td>xyz\"xyz</td>" + lineSeparator()
+    assertThat(event.getMessage().getPayload().getValue(), equalTo("<td>#[</td>\n"
+        + "<td>abcd#[-1234WORLD.log</td>\n"
+        + "<td>'abc'def'</td>\n"
+        + "<td>abc'def</td>\n"
+        + "<td>\"xyz\"xyz\"</td>\n"
+        + "<td>xyz\"xyz</td>\n"
         + "<td>abc$DEF#ghi\\[JKL]</td>"));
   }
 


### PR DESCRIPTION
The test assertions were failing because the expected payloads use "\n" as the line separator instead of the platform-dependent value returned by lineSeparator(). This caused mismatches on systems where lineSeparator() returns "\r\n". 

To ensure consistency across environments, replaced occurrences of lineSeparator() with "\n" in the affected tests.